### PR TITLE
Removed padding on .textitem

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -41,7 +41,6 @@ h1
 
 .textItem
   width: 100%
-  padding: 20px 0
   text-align: center
   font-family: $font-stack
   font-size: 20px


### PR DESCRIPTION
This was making the clickboxes too big. I cannot see any bugs this produces with light testing.
Closes #17 
