### PR TITLE
BathroomsController#encode_search cleanup

### DIFF
--- a/app/controllers/bathrooms_controller.rb
+++ b/app/controllers/bathrooms_controller.rb
@@ -121,8 +121,16 @@ class BathroomsController < ApplicationController
         params[:search] = "#{params[:lat]}, #{params[:long]}"
 
       else
-        # Only one of the latitude or longitude parameters is blank.
-        # FIXME: I'm not sure how this could ever happen. Do we need to handle it? If so, how?
+        # The search parameter is empty, but only *one* of the latitude or
+        # longitude parameters is blank.
+        # We can't really recover from this, so redirect to the homepage and
+        # show an error.
+
+        params.delete(:lat)
+        params.delete(:long)
+
+        error = "There was an error searching for your location."
+        redirect_to url_for(params), flash: {error: error}
       end
     end
   end


### PR DESCRIPTION
Cleaned up encode_search a bit.

The cases where the `search` parameter is specified, but either (or both) of `lat` and `long` are not specified, is not handled because this would need to be client-side, given how lat/long are being handled. That will be a separate PR. This one should handle all of the other variants of parameters being specified or not specified, however.
