### PR TITLE
Extract secrets to environment. Fixes #29

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  config.secret_key = '9ae01ec3f7260fffa5e2e73f3319d85470456435e971280feaa9ba2d646fcfb8433cdba9e7e76ea5b9353d5f5d5a9785fef9d226dd8e807cad10a47680a27aac'
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,4 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-SaferstallsRails::Application.config.secret_key_base = 'd1cbcde3c2974765f485a8189855c1d5776909a179b62870b219b3dc784137d7d18dadbe7206fbaecb3d9685265af7d04d5b3e6da27153f0c2d272f4cd6ca493'
+SaferstallsRails::Application.config.secret_key_base = ENV['RAILS_SECRET_KEY']


### PR DESCRIPTION
New secrets can be generated with `rake secret`. The secrets can be
placed in .env in development. On Heroku, run `config:set`:
heroku config:set RAILS_SECRET_KEY=[x] DEVISE_SECRET_KEY=[y]

Unfortunately, changing the secrets will break existing session and
login cookies, but there's no avoiding that, as having the secrets
shared publicly as they are currently is a security hole.
