### PR TITLE
Add Rake task to fix safe2pee encoding problems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project is open source. Feel free to contribute. We could use the help.
 2. Make sure you have Ruby 2.0 and PostgreSQL (on Mac, it's recommended to install Postgres with [homebrew](http://brew.sh/)).
 3. In the repository directory run <code>bundle install</code> to install all dependencies.
 4. Make sure Postgres is running, then run <code>rake db:setup</code>. This will create the development database, set it up for the application and fill it with the original safe2pee data, which you can use during development.
+5. Optionally, run <code>rake db:fix_accents</code> to clean up encoding problems in the safe2pee data. (Use <code>rake db:fix_accents[dry_run]</code> to preview the changes.)
 
 ## Tech
 

--- a/lib/tasks/fix_accents.rake
+++ b/lib/tasks/fix_accents.rake
@@ -1,0 +1,53 @@
+namespace :db do
+  desc "Fix wrongly-encoded accented characters (use db:fix_accents[dry_run] to preview changes)"
+  task :fix_accents, [:dry_run] => [:environment] do |t, args|
+    args.with_defaults(dry_run: false)
+
+    transformations = {
+      "Ž" => "é",
+      "™" => "ô",
+      "&Atilde;&uml;" => "è",
+      "&Atilde;&copy;" => "é",
+      "&iuml;&iquest;&frac12;Restroom&iuml;&iquest;&frac12;" => "'Restroom'",
+      "&iuml;&iquest;&frac12; " => "é ",
+      "ÌÊ" => "à",
+      "Ì«" => "ô",
+      "Ì©" => "é",
+      "Ì¬s" => "’s",
+      "Ì¬" => "è",
+      "Ì¨" => "î",
+      "Ìø" => "ï",
+      "ÌÛ" => "À",
+      "\u008F" => "è",
+      "&Atilde;&iexcl;" => "á",
+      "&amp;" => "&",
+      "&Atilde;&sect;" => "ç"
+    }
+
+    if args.dry_run
+      puts "Dry running fix_accents"
+    else
+      puts "Running fix_accents"
+    end
+
+    puts ""
+
+    fields = [:name, :street, :city, :directions, :comment]
+
+    fields.each do |field|
+      where_clause = transformations.keys.map{|original| "#{field} like '%#{original}%'"}.join(" OR ")
+
+      puts field, "="*field.length,""
+
+      Bathroom.where(where_clause).each do |bathroom|
+        transformations.each do |original, transformed|
+          bathroom.send("#{field}=", bathroom.send(field).gsub(original, transformed))
+        end
+
+        puts bathroom.id, "", bathroom.send("#{field}_was"), "", bathroom.send(field), "\n\n"
+
+        bathroom.save unless args.dry_run
+      end
+    end
+  end
+end


### PR DESCRIPTION
The seed data from safe2pee is a confusion of encodings, more easily
noticed where I live in Montréal. This Rake task applies
heuristically-determined transformations to fix legacy encoding errors
carried over from safe2pee.

It includes a "dry run" flag to allow you to preview the results of the
transformation before applying them to the database. This need only be
run once on the production database, but developers can also use it to
massage the seed data when running locally.
