### PR TITLE
Partially restore styling to links in footer and make them more accessible to screenreaders

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,3 +11,39 @@
  *= require_self
  *= require_tree .
  */
+
+.icon {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: {
+    size: 200% 100%;
+    position: 0 50%;
+  }
+  padding: 12px;
+  margin: 4px;
+  
+	&:hover {
+    background-position: 100% 50%;
+  }
+  
+  &.iconGitHub {
+    background-image: asset-url('buttons_github.svg');
+  }
+  
+  &.iconTwitter {
+    background-image: asset-url('buttons_twitter.svg');
+  }
+  
+  &.iconFacebook {
+    background-image: asset-url('buttons_facebook.svg');
+  }
+  
+  &.iconTumblr {
+    background-image: asset-url('buttons_tumblr.svg');
+  }
+
+  &.iconEmail {
+    background-image: asset-url('buttons_mail.svg');
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,20 +29,24 @@
 
         <footer>
           <div class="footer">
-          <a HREF="https://github.com/tkwidmer/refugerestrooms" class="icon iconGitHub"></a>
-          <a HREF="https://twitter.com/refugerestrooms" class="icon iconTwitter"></a> 
-          <a HREF="https://www.facebook.com/refugerestrooms" class="icon iconFacebook"></a> 
-          <a HREF="http://blog.refugerestrooms.org/" class="icon iconTumblr"></a>
-          <a href="<%= contact_path %>" class="icon iconEmail"></a>
-          <br/>
+            <a href="https://github.com/tkwidmer/refugerestrooms">
+              <img class="icon iconGitHub" alt="Refuge Restrooms on github" /></a>
+            <a href="https://twitter.com/refugerestrooms">
+              <img class="icon iconTwitter" alt="Refuge Restrooms on twitter"></a> 
+            <a href="https://www.facebook.com/refugerestrooms">
+              <img class="icon iconFacebook" alt="Refuge Restrooms on facebook"></a> 
+            <a href="http://blog.refugerestrooms.org/">
+              <img class="icon iconTumblr" alt="Refuge Restrooms's blog on tumblr"></a>
+            <a href="<%= contact_path %>">
+              <img class="icon iconEmail" alt="Email Refuge Restrooms"></a>
+            <br/>
             refuge restrooms is open source.  
-          <a HREF="https://github.com/tkwidmer/refugerestrooms"> code on github. </a> <br> &copy; copyleft 2014 refuge restrooms.
-
+            <a href="https://github.com/tkwidmer/refugerestrooms"> code on github. </a> 
+            <br/>
+            &copy; copyleft 2014 refuge restrooms.
           </div>
-      </footer>
-    </div>
-
-
+        </footer>
+      </div>
     </main>
   </body>
 </html>


### PR DESCRIPTION
As part of the move from Suzy to Bootstrap, most styling was removed.  This commit:
- restores icon images to links in footer
- adds img tags so that alt attributes can be added for screenreaders
- fixes minor indentation and capitalization nits in the primary layout file
