### PR TITLE
Retrieve Active Admin gem over SSL/TLS;

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'jbuilder', '~> 1.2'
 gem 'geocoder'
 
 # Use Active Admin
-gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'activeadmin', git: 'https://github.com/gregbell/active_admin.git'
 
 # Use country_select plugin
 gem 'country_select'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/gregbell/active_admin.git
+  remote: https://github.com/gregbell/active_admin.git
   revision: 60d8be97ec2c29a871f55bd28e00ca9ec9257028
   specs:
     activeadmin (1.0.0.pre)


### PR DESCRIPTION
So, unfortunately, the `github:` shorthand in Gemfiles resolve to the `git://` protocol which is, surprisingly, insecure.

The rubysec organization recommends that all Gem sources should be accessed over SSL/TLS.
