### PR TITLE
Fix typo in about page

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -14,7 +14,7 @@
 
 <div class="centerText">
   <p>
-	This website is currently functional yet still under development. You may find that there are bugs. If you find any please submit an issue on github, or send us a <%= link_to 'message', contact_path %> so that we can resolve the issue ASAP. This is an Open Source project and we encourage you to contribute on github.</p>
+	This website is currently functional yet still under development. You may find that there are bugs. If you find any please submit an issue on GitHub, or send us a <%= link_to 'message', contact_path %> so that we can resolve the issue ASAP. This is an Open Source project and we encourage you to contribute on GitHub.</p>
 	<br/>
 </div>
  


### PR DESCRIPTION
Hi Geoff,
I made a change to github. I changed it to display the word as GitHub instead of github. 
Renae
