### PR TITLE
Restore search from splash page

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -180,24 +180,26 @@ h1 {
   color: white;
 }
 
-.searchButton {
-  position: absolute;
-  top: 5px;
-  right: 0;
-  padding-right: 2px;
-  padding-left: 2px;
-  width: 50px;
-  height: 50px;
+.header {
+  .searchButton, .currentLocationButton {
+    position: absolute;
+    top: 5px;
+    padding-right: 2px;
+    padding-left: 2px;
+    width: 50px;
+    height: 50px;
+  }
+
+  .searchButton {
+    right: 0;
+  }
+
+  .currentLocationButton {
+    right: 60px;
+  }
 }
 
-.currentLocationButton {
-  position: absolute;
-  top: 5px;
-  right: 60px;
-  padding-right: 2px;
-  padding-left: 2px;
-  width: 50px;
-  height: 50px;
+.search .currentLocationButton {
   word-wrap: break-word;
   background: #FFF asset-url('currentLocation.png') no-repeat;
   background-size: 75%;

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,11 +1,14 @@
-<div class="search">  
+<% splash = false if local_assigns[:splash].nil? %>
+<div class="search">
   <%= form_tag bathrooms_path, :method => :get do %>
-    <div class="searchBarContainer">
-      <%= text_field_tag :search, params[:search], :class => "searchBar" %>
-    </div>
-    <%= submit_tag "Search", :type => 'button', :name => nil, :class=> "whitelinkbutton searchButton submitButton" %>
-    <%= hidden_field_tag :lat, "" %>
-    <%= hidden_field_tag :long, "" %>
-    <%= submit_tag "", :type => 'button', :name => nil, :class=> "whitelinkbutton currentLocationButton", :title => 'Search by current location' %>
+    <%= content_tag (splash ? :center : :div) do %>
+      <div class="searchBarContainer">
+        <%= text_field_tag :search, params[:search], :class => "searchBar" %>
+      </div>
+      <%= hidden_field_tag :lat, "" %>
+      <%= hidden_field_tag :long, "" %>
+      <%= submit_tag "Search", :type => 'button', :name => nil, :class=> "searchButton submitButton btn btn-default" %>
+      <%= submit_tag "", :type => 'button', :name => nil, :class=> "currentLocationButton btn btn-default", :title => 'Search by current location', :value => (splash ? "Search Current Location" : nil) %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,16 +1,7 @@
 <div class="imgsplash">
   <%= image_tag('logo-dark.svg') %>
 </div>
-<div class="splashsearchcontainer"><center>
-  <%= form_tag bathrooms_path, :method => :get do %>
-  <%= text_field_tag :search, params[:search], :style => "width: 50%;" %> <br>
-  <%= submit_tag "Search", :type => 'button', :name => nil, :class=> "btn btn-default" %>
-  <%= hidden_field_tag :lat, "" %>
-  <%= hidden_field_tag :long, "" %>
-  <%= submit_tag "Search Current Location", :type => 'button', :name => nil, :class=> "btn btn-default", :title => 'Search by current location' %>
-  <% end %>
-  </center>
-</div>
+<%= render partial: "layouts/search", locals: {splash: true} %>
 
 <div class="centerText">
   <p>


### PR DESCRIPTION
Fixes #99

This removes the custom search field that was on the splash page and uses the search partial instead. It’s a bit hackish in order to tweak the search based on where it’s being included, because the form had a different appearance on the splash page, but this could be addressed as part of a general cleanup. (The `<center>` tag is considered something to avoid, for instance.)
