### PR TITLE
Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+cache: bundler
+script:
+  - bundle exec rake
+  - bundle exec rspec
+rvm:
+  - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ end
 
 group :test do
   gem 'minitest-rails', '~> 0.9.2'
+  gem 'rake'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,7 @@ DEPENDENCIES
   pg_search
   rails (= 4.0.0)
   rails_12factor
+  rake
   rspec-rails (~> 3.0.0.beta)
   sass-rails
   sdoc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Stories in Ready](https://badge.waffle.io/tkwidmer/refugerestrooms.png?label=ready)](https://waffle.io/tkwidmer/refugerestrooms)
+[![Build Status](https://travis-ci.org/tkwidmer/refugerestrooms.svg)](https://travis-ci.org/tkwidmer/refugerestrooms) [![Stories in Ready](https://badge.waffle.io/tkwidmer/refugerestrooms.png?label=ready)](https://waffle.io/tkwidmer/refugerestrooms)
 # REFUGE restrooms
 
 Providing safe restroom access for transgender, intersex, and gender noncomforming individuals.


### PR DESCRIPTION
As discussed in #99. There are already tests that [pass](https://travis-ci.org/backspace/refugerestrooms/builds/22124960), though they aren’t the acceptance tests that I described in the other thread, which I can get started on in another branch.

I added a Travis badge to the readme, but it will show “unknown” because the original repository isn’t set up with Travis yet. If you want to merge in this pull request, follow Travis’s [getting started guide](http://docs.travis-ci.com/user/getting-started/), and once you enable it for the refugerestrooms repository, the build status will be displayed correctly on GitHub!

Here’s the build status for my branch: ![integrate-travis-ci branch build status](https://travis-ci.org/backspace/refugerestrooms.svg?branch=integrate-travis-ci)
