### PR TITLE
Hide location icon on splash, restore spinner when loading

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -206,7 +206,11 @@ h1 {
   background-position: 50%;
 }
 
-.currentLocationButtonLocating {
+.splashcontainer .currentLocationButton {
+  background-image: none;
+}
+
+.search .currentLocationButtonLocating {
   background: #fff asset-url('loading.gif');
   background-repeat: no-repeat;
   background-position: 50%;

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -32,6 +32,4 @@
         </li>
       </ul>
     </div><!-- /.navbar-collapse -->
-
-  </div><!-- /.container-fluid -->
 </nav>


### PR DESCRIPTION
This also fixes a hierarchy problem where an extra div was being closed in _navigation, which puts all the content of the splash page in its proper container.

I missed some details when using the same partial for both places search was implemented, this fixes them.
