### PR TITLE
Restore listing of nearby restrooms on suggestion page

### DIFF
--- a/app/views/bathrooms/_formsubmit.html.erb
+++ b/app/views/bathrooms/_formsubmit.html.erb
@@ -9,6 +9,9 @@
       </div>
     </div>
 
+    <div id="nearby">
+    </div>
+
     <%= f.input :name, :required => true %>
     <%= f.input :street, :required => true %>
     <%= f.input :city, :required => true %>


### PR DESCRIPTION
Hey @tkwidmer, I noticed the latest build failed because the nearby restroom markup had nowhere to go when returned via AJAX. I’m pretty new to this sort of collaboration and maybe I could have planned my pull requests better because I did wonder beforehand whether the merge might cause trouble. Anyway, simple fix, should restore the build to passing, sorry for the hassle.
