### PR TITLE
Restore styling of restrooms near guessed location

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,7 @@
  *
  *= require_self
  *= require framework_and_overrides
+ *= require bathrooms
  *= require nav
  *= require search
  */


### PR DESCRIPTION
In [this commit](https://github.com/tkwidmer/refugerestrooms/commit/92d9965f71263f4a2bbf2c0cdd56290408b63862) I moved away from using `require_tree` (see [`require_tree` is evil](http://craiccomputing.blogspot.com/2012/10/rails-32-asset-pipeline-requiretree-is.html)) because it was including the Active Admin stylesheet and causing weird style overlaps. But I forgot to include the `bathrooms.css.scss` stylesheet, so the nearby restrooms weren’t getting the smaller-than-default styling. This fixes the styling.
