### PR TITLE
Rein in the header's width to match the content.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -91,11 +91,6 @@ h1 {
   margin: 0 auto;
 }
 
-.header {
-  position: relative;
-  background: $purple;
-}
-
 .nav {
   background: $purple;
 }

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -19,7 +19,7 @@ img {
 
 .navbar-default {
   width: 100%;
-  background-color: #41326B;
+  background-color: transparent;
   border-color: #41326B;
 }
 
@@ -27,12 +27,22 @@ img {
   color: white;
   text-decoration: none; }
 
+header {
+  background-color: $purple;
+}
+
 // THESE ARE EXAMPLES YOU CAN MODIFY
 // create your own classes
 // to make views framework-neutral
 
-.container{
+.constraint {
+  position: relative;
   max-width: 940px;
+  margin: auto;
+}
+
+.container {
+  @extend .constraint;
   background-color: ffffff;
 }
 

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -1,4 +1,4 @@
-%nav.nav.navbar-default{:role => "navigation"}
+%nav.nav.navbar-default.constraint{:role => "navigation"}
   / Brand and toggle get grouped for better mobile display
   .navbar-header
     %a#logo.toiletLogo{:href => "/"}

--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -1,5 +1,5 @@
 - splash = false if local_assigns[:splash].nil?
-.search
+.search.constraint
   = form_tag restrooms_path, :method => :get do
     = content_tag (splash ? :center : :div) do
       .searchBarContainer


### PR DESCRIPTION
Before:

![refuge-restrooms-header-before](https://cloud.githubusercontent.com/assets/39698/2690666/8a088244-c358-11e3-8cde-3a5a009ff982.png)

After:

![refuge-restrooms-header-after](https://cloud.githubusercontent.com/assets/39698/2690664/77483adc-c358-11e3-8e55-8b023cb8c0d1.png)
