### PR TITLE
Add animation to guess button when loading

### DIFF
--- a/app/assets/javascripts/formsubmit.js
+++ b/app/assets/javascripts/formsubmit.js
@@ -1,5 +1,7 @@
 $(function () {
   $("#guess").click(function () {
+    $("#guess").toggleClass('locating');
+
     getCurrent(function (pos) {
       $('.currentLocationButton').removeClass('currentLocationButtonLocating');
 

--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -60,7 +60,7 @@
  }
 }
 
-.search .currentLocationButtonLocating {
+.search .currentLocationButtonLocating, #guess.locating {
   background: #fff asset-url('loading.gif');
   background-repeat: no-repeat;
   background-position: 50%;


### PR DESCRIPTION
Though the location button in the header has a loading animation when guessing the current location on the new bathrooms page, it didn’t seem noticeable enough to me, so I made the guess button animate as well. Maybe the header button shouldn’t even be animated, it doesn’t quite make sense, from a user experience perspective, I think.
