### PR TITLE
Fix underline on footer buttons, increase readability of splash page/search bar buttons

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -646,3 +646,7 @@ footer {
     font-size: 15px;
   }
 }
+
+a.iconLink {
+  text-decoration:none;
+}

--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -68,3 +68,8 @@
     background-color: white;
   }
 }
+
+.searchButton:hover,.splashcontainer .currentLocationButton:hover {
+  background-color:#8377af;
+  border-color:#8377af;
+}

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,14 +1,14 @@
 %footer
   .footer
-    %a{:href => "https://github.com/RefugeRestrooms/refugerestrooms"}
+    %a.iconLink{:href => "https://github.com/RefugeRestrooms/refugerestrooms"}
       %img.icon.iconGitHub{:src => asset_path("clear.png"), :alt => "Refuge Restrooms on github"}/
-    %a{:href => "https://twitter.com/refugerestrooms"}
+    %a.iconLink{:href => "https://twitter.com/refugerestrooms"}
       %img.icon.iconTwitter{:src => asset_path("clear.png"), :alt => "Refuge Restrooms on twitter"}/
-    %a{:href => "https://www.facebook.com/refugerestrooms"}
+    %a.iconLink{:href => "https://www.facebook.com/refugerestrooms"}
       %img.icon.iconFacebook{:src => asset_path("clear.png"), :alt => "Refuge Restrooms on facebook"}/
-    %a{:href => "http://blog.refugerestrooms.org/"}
+    %a.iconLink{:href => "http://blog.refugerestrooms.org/"}
       %img.icon.iconTumblr{:src => asset_path("clear.png"), :alt => "Refuge Restrooms's blog on tumblr"}/
-    %a{:href => contact_path}
+    %a.iconLink{:href => contact_path}
       %img.icon.iconEmail{:src => asset_path("clear.png"), :alt => "Email Refuge Restrooms"}/
     %br/
     refuge restrooms is open source.


### PR DESCRIPTION
![screenshot_20140524_114329](https://cloud.githubusercontent.com/assets/1895116/3074919/310ab7e4-e35a-11e3-9e8c-e7aa8aacc2ec.png)
![screenshot_20140525_103016](https://cloud.githubusercontent.com/assets/1895116/3077198/1f1ee36a-e419-11e3-9795-a056f8811cae.png)
Removes those little lines, a result of the default a:hover of bootstrap having text-decoration:underline

![screenshot_20140524_113901](https://cloud.githubusercontent.com/assets/1895116/3074897/b851169a-e359-11e3-88c3-4e18a56cb2d6.png)
In addition, this button's hover state is pretty difficult to read for those with any vision/processing issues. This branch changes the grey to the light purple used elsewhere (#8377af).

![screenshot_20140524_113856](https://cloud.githubusercontent.com/assets/1895116/3074914/e0c7cdb2-e359-11e3-94b4-a7b2c6546b3f.png)
Lastly, the text in the splash page's Search Current Location button completely disappears on hover- changed this to give just this instance of the button the same light purple (#8377af) background on hover.

The buttons will now look like this on :hover 
![screenshot_20140525_102937](https://cloud.githubusercontent.com/assets/1895116/3077606/ee528808-e437-11e3-9591-67deca825c87.png)
![screenshot_20140525_102933](https://cloud.githubusercontent.com/assets/1895116/3077607/ee5370b0-e437-11e3-9c30-6d91c5bb9821.png)
