### PR TITLE
Titleize restroom name and street name

### DIFF
--- a/app/views/restrooms/_restroom.html.haml
+++ b/app/views/restrooms/_restroom.html.haml
@@ -2,8 +2,8 @@
   .listItemImage
     / image tag goes here
   .itemInfo
-    .itemName= link_to_unless_current(restroom.name, restroom)
-    .itemStreet="#{restroom.street}, #{restroom.city}, #{restroom.state}"
+    .itemName= link_to_unless_current(restroom.name.titleize, restroom)
+    .itemStreet="#{restroom.street.titleize}, #{restroom.city}, #{restroom.state}"
     - if restroom.rated?
       - rating_class_name = case RatingLevel.for_restroom(restroom)
       - when RatingLevel.green  then 'greenRating'


### PR DESCRIPTION
Make the formatting of the restroom name and street name look a little better by titleize-ing them.

It might be incorrect for some places, but I think it's better overall!
