### PR TITLE
Feature/display current year in copyleft

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -14,4 +14,4 @@
     refuge restrooms is open source.
     %a{:href => "https://github.com/RefugeRestrooms/refugerestrooms"} code on github.
     %br/
-    \&copy; copyleft 2014 refuge restrooms.
+    = "\&copy; copyleft #{Date.today.year} refuge restrooms."

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -14,4 +14,4 @@
     refuge restrooms is open source.
     %a{:href => "https://github.com/RefugeRestrooms/refugerestrooms"} code on github.
     %br/
-    = "\&copy; copyleft #{Date.today.year} refuge restrooms."
+    = "\&copy; copyleft #{Date.today.year} refuge restrooms.".html_safe


### PR DESCRIPTION
It's the little things that annoy.. Keep the year up to date on the copyleft notice.