### PR TITLE
Add specific permitted params for restrooms

### DIFF
--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -77,6 +77,18 @@ private
   end
 
   def permitted_params
-    params.require(:restroom).permit!
+    params.require(:restroom).permit(
+      :name,
+      :street,
+      :city,
+      :state,
+      :country,
+      :accessible,
+      :unisex,
+      :directions,
+      :comment,
+      :longitude,
+      :latitude
+    )
   end
 end


### PR DESCRIPTION
Found this vulnerability with `brakeman`. 

Instead of calling `permit!` we should be using strong params to allow only the params we want. 