### PR TITLE
Add blocked flag to restrooms

### DIFF
--- a/app/assets/stylesheets/restrooms.css.scss
+++ b/app/assets/stylesheets/restrooms.css.scss
@@ -70,7 +70,7 @@
         max-width: 100%;
     }
 
-    // ADA / Gender Neutral Filters
+    // ADA / Gender Neutral / Blocked Filters
     .itemExtraInfo {
         position: absolute;
         top: 20px;
@@ -83,6 +83,9 @@
     .ADARestroom {
         width: 44px;
         height: 47px;
+    }
+    .blockedRestroom {
+      color: red;
     }
     .unisexRestroom img, .ADARestroom img {
         width: 100%;

--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -41,6 +41,8 @@ class Restroom < ActiveRecord::Base
 
   scope :accessible, -> { where(accessible: true) }
   scope :unisex, -> { where(unisex: true) }
+  scope :blocked, -> { where(blocked: true) }
+  scope :safe, -> { where(blocked: false) }
 
   scope :created_since, ->(date) { where("created_at >= ?", date) }
   scope :updated_since, ->(date) { where("updated_at >= ?", date) }

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -19,6 +19,7 @@
   = f.hidden_field :longitude
   = f.input :accessible, :collection => [[t('restroom.accessible'), true], [t('restroom.not_accessible'), false]], :include_blank => false
   = f.input :unisex, :collection => [[t('restroom.type.unisex'), true], [t('restroom.type.single_stall'), false]], :include_blank => false
+  = f.input :blocked, :collection => [[t('restroom.safe'), false], [t('restroom.blocked'), true]], :default => false, :include_blank => false
   = f.input :directions, :placeholder => t('restroom.directions_hint'), :as => :text, :required => false, :input_html => { :class => "span6" }
   = f.input :comment, :placeholder => t('restroom.comments_hint'), :as => :text, :required => false, :input_html => { :class => "span6" }
   = f.button :submit, t('restroom.restsubmit'), :class => "linkbutton"

--- a/app/views/restrooms/_restroom.html.haml
+++ b/app/views/restrooms/_restroom.html.haml
@@ -26,3 +26,6 @@
     - if restroom.accessible?
       .ADARestroom
         %i.fa.fa-wheelchair.fa-3x
+    - if restroom.blocked?
+      .blockedRestroom
+        %i.fa.fa-ban.fa-3x

--- a/config/locales/restroom.en.yml
+++ b/config/locales/restroom.en.yml
@@ -14,6 +14,8 @@ en:
     add_new: 'Submit a restroom to our database'
     required: '* marks required field'
     guess_location: 'Guess current location'
+    blocked: 'Add restroom to blocked list'
+    safe: 'Do not add restroom to blocked list'
     directions: 'Directions'
     directions_hint: '(e.g.: third floor in the back, by the dressing rooms...)'
     comments_hint: '(e.g.: you have to be a "paying customer", just act like you are browsing for a bit...)'

--- a/db/migrate/20151015004853_add_blocked_flag_to_restrooms.rb
+++ b/db/migrate/20151015004853_add_blocked_flag_to_restrooms.rb
@@ -1,0 +1,5 @@
+class AddBlockedFlagToRestrooms < ActiveRecord::Migration
+  def change
+    add_column :restrooms, :blocked, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140423031801) do
+ActiveRecord::Schema.define(version: 20151015004853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20140423031801) do
     t.integer  "downvote",   default: 0
     t.integer  "upvote",     default: 0
     t.string   "country"
+    t.boolean  "blocked",    default: false
   end
 
 end


### PR DESCRIPTION
This is one possible approach to https://github.com/RefugeRestrooms/refugerestrooms/issues/241

It adds a flag on restrooms for blocked, and a dropdown on the restroom form for users to add the blocked flag.
<img width="804" alt="screen shot 2015-10-14 at 9 42 04 pm" src="https://cloud.githubusercontent.com/assets/5439589/10502696/a2f4e3fa-72bc-11e5-94f2-c6b515052f20.png">
Blocked restrooms have a "ban" icon on the show page.
<img width="113" alt="screen shot 2015-10-14 at 9 44 11 pm" src="https://cloud.githubusercontent.com/assets/5439589/10502720/dd6dab70-72bc-11e5-87e1-53147016b7a7.png">

But this raises a couple questions:
- How to message "blocking," do you want to have a page that explains "blockable" conduct?
- How to deal with these restrooms in API queries, etc. since these are essentially anti-recommendations, we don't people to accidentally go to them when looking for a safe space.

Let me know your thoughts.
