### PR TITLE
Changing tables

### DIFF
--- a/app/assets/javascripts/views/restrooms/restrooms.js.coffee
+++ b/app/assets/javascripts/views/restrooms/restrooms.js.coffee
@@ -3,15 +3,20 @@
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
 $ ->
-  $('#ada_filter').click -> 
+  $('#ada_filter').click ->
     if $(this).hasClass("active")
       $('.listItem.not_accessible').show()
-    else 
+    else
       $('.listItem.not_accessible').hide()
-    
-  $('#unisex_filter').click -> 
+
+  $('#unisex_filter').click ->
     if $(this).hasClass("active")
       $('.listItem.not_unisex').show()
-    else 
+    else
       $('.listItem.not_unisex').hide()
 
+  $('#changing_table_filter').click ->
+    if $(this).hasClass("active")
+      $('.listItem.no_changing_table').show()
+    else
+      $('.listItem.no_changing_table').hide()

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -19,6 +19,7 @@
   = f.hidden_field :longitude
   = f.input :accessible, :collection => [[t('restroom.accessible'), true], [t('restroom.not_accessible'), false]], :include_blank => false
   = f.input :unisex, :collection => [[t('restroom.type.unisex'), true], [t('restroom.type.single_stall'), false]], :include_blank => false
+  = f.input :changing_table, :collection => [[t('restroom.changing_table'), true], [t('restroom.no_changing_table'), false]], :include_blank => false
   = f.input :directions, :placeholder => t('restroom.directions_hint'), :as => :text, :required => false, :input_html => { :class => "span6" }
   = f.input :comment, :placeholder => t('restroom.comments_hint'), :as => :text, :required => false, :input_html => { :class => "span6" }
   = f.button :submit, t('restroom.restsubmit'), :class => "linkbutton"

--- a/app/views/restrooms/_restroom.html.haml
+++ b/app/views/restrooms/_restroom.html.haml
@@ -1,4 +1,9 @@
-%div{:class => "listItem #{restroom.unisex? ? '' : 'not_unisex'} #{restroom.accessible? ? '' : 'not_accessible'} #{restroom.changing_table? ? '' : 'no_changing_table'}", "data-id" => restroom.id}
+- unisex_class = restroom.unisex? '' : 'not_unisex'
+- accessible_class = restroom.accessible? '' : 'not_accessible'
+- changing_table_class = restroom.accessible? '' : 'no_changing_table'
+
+%div{ class: "listItem #{unisex_class} #{accessible_class} #{changing_table_class}",
+          "data-id": restroom.id}
   .listItemImage
     / image tag goes here
   .itemInfo

--- a/app/views/restrooms/_restroom.html.haml
+++ b/app/views/restrooms/_restroom.html.haml
@@ -1,9 +1,9 @@
-- unisex_class = restroom.unisex? '' : 'not_unisex'
-- accessible_class = restroom.accessible? '' : 'not_accessible'
-- changing_table_class = restroom.accessible? '' : 'no_changing_table'
+- unisex_class = restroom.unisex? ? '' : 'not_unisex'
+- accessible_class = restroom.accessible? ? '' : 'not_accessible'
+- changing_table_class = restroom.accessible? ? '' : 'no_changing_table'
 
 %div{ class: "listItem #{unisex_class} #{accessible_class} #{changing_table_class}",
-          "data-id": restroom.id}
+          data: { id: restroom.id} }
   .listItemImage
     / image tag goes here
   .itemInfo

--- a/app/views/restrooms/_restroom.html.haml
+++ b/app/views/restrooms/_restroom.html.haml
@@ -1,4 +1,4 @@
-%div{:class => "listItem #{restroom.unisex? ? '' : 'not_unisex'} #{restroom.accessible? ? '' : 'not_accessible'}", "data-id" => restroom.id}
+%div{:class => "listItem #{restroom.unisex? ? '' : 'not_unisex'} #{restroom.accessible? ? '' : 'not_accessible'} #{restroom.changing_table? ? '' : 'no_changing_table'}", "data-id" => restroom.id}
   .listItemImage
     / image tag goes here
   .itemInfo
@@ -26,3 +26,6 @@
     - if restroom.accessible?
       .ADARestroom
         %i.fa.fa-wheelchair.fa-3x
+    - if restroom.changing_table?
+      .changingTable
+        %i.fa.fa-child.fa-3x

--- a/app/views/restrooms/index.html.haml
+++ b/app/views/restrooms/index.html.haml
@@ -8,6 +8,9 @@
         %label#unisex_filter.filter.btn-light-purple.btn.linkbutton
           %input{:type => "checkbox"}
           %i.fa.fa-transgender-alt
+        %label#changing_table_filter.filter.btn-light-purple.btn.linkbutton
+          %input{:type => "checkbox"}
+          %i.fa.fa-child
 
       .map-toggle-btn.mapToggle.filter.linkbutton.btn-light-purple
         Map View

--- a/config/locales/restroom.en.yml
+++ b/config/locales/restroom.en.yml
@@ -20,6 +20,8 @@ en:
     comments: 'Comments'
     accessible: 'Accessible'
     not_accessible: 'Not accessible'
+    changing_table: 'Changing table'
+    no_changing_table: 'No changing table'
     type:
       unisex: 'Unisex / Gender neutral'
       single_stall: 'Gendered single stall or safe place'

--- a/db/migrate/20151018191859_add_changing_table_flag_to_restrooms.rb
+++ b/db/migrate/20151018191859_add_changing_table_flag_to_restrooms.rb
@@ -1,0 +1,5 @@
+class AddChangingTableFlagToRestrooms < ActiveRecord::Migration
+  def change
+    add_column :restrooms, :changing_table, :boolean
+  end
+end

--- a/db/migrate/20151018191859_add_changing_table_flag_to_restrooms.rb
+++ b/db/migrate/20151018191859_add_changing_table_flag_to_restrooms.rb
@@ -1,5 +1,5 @@
 class AddChangingTableFlagToRestrooms < ActiveRecord::Migration
   def change
-    add_column :restrooms, :changing_table, :boolean
+    add_column :restrooms, :changing_table, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 20151018191859) do
     t.integer  "downvote",   default: 0
     t.integer  "upvote",     default: 0
     t.string   "country"
-    t.boolean  "changing_table"
+    t.boolean  "changing_table", default: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140423031801) do
+ActiveRecord::Schema.define(version: 20151018191859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20140423031801) do
     t.integer  "downvote",   default: 0
     t.integer  "upvote",     default: 0
     t.string   "country"
+    t.boolean  "changing_table"
   end
 
 end

--- a/spec/models/restroom_spec.rb
+++ b/spec/models/restroom_spec.rb
@@ -41,6 +41,11 @@ describe Restroom do
     it { expect(Restroom.new(accessible: true).accessible?).to be true }
   end
 
+  describe '#changing_table?' do
+    it { expect(Restroom.new.changing_table?).to be false }
+    it { expect(Restroom.new(changing_table: true).changing_table?).to be true }
+  end
+
   describe '#topcities' do
     it 'should return the top five cities with the most restroom data' do
       city_with_more_data = "City1"


### PR DESCRIPTION
Add field to indicate whether a restroom has a changing table, per: https://github.com/RefugeRestrooms/refugerestrooms/issues/233

I don't know what icon should be used for this. The best I could come up with was the fa-child one, but I think there's probably better out there, open to suggestions.

Screenshots:
<img width="262" alt="screen shot 2015-10-18 at 4 09 01 pm" src="https://github-cloud.s3.amazonaws.com/assets/5439589/10566345/ae47f26c-75b2-11e5-9d6a-89e1d0b4958b.png">
<img width="1226" alt="screen shot 2015-10-18 at 4 08 42 pm" src="https://github-cloud.s3.amazonaws.com/assets/5439589/10566351/c1000f98-75b2-11e5-9cd6-bbc25fa34b7b.png">

@tkwidmer 