### PR TITLE
[test] fix URL for restrooms_spec

### DIFF
--- a/spec/api/v1/restrooms_spec.rb
+++ b/spec/api/v1/restrooms_spec.rb
@@ -178,7 +178,7 @@ describe "Restrooms API", type: :request do
     context "filters a list of restrooms by updated date" do
       before :each do
         FactoryGirl.create(:restroom, created_at: 1.day.ago)
-        get "api/v1/restrooms/by_date", updated: true,  day: Date.today.day, month: Date.today.month, year: Date.today.year
+        get "/api/v1/restrooms/by_date", updated: true,  day: Date.today.day, month: Date.today.month, year: Date.today.year
       end
 
       it "is successful" do


### PR DESCRIPTION
Without the leading slash:

```
  1) Restrooms API queries filters a list of restrooms by updated date finds all restrooms
     Failure/Error: get "api/v1/restrooms/by_date", updated: true,  day: Date.today.day, month: Date.today.month, year: Date.today.year
     URI::InvalidURIError:
       bad URI(is not URI?): http://www.example.com:80api/v1/restrooms/by_date
     # ./spec/api/v1/restrooms_spec.rb:181:in `block (4 levels) in <top (required)>'

  2) Restrooms API queries filters a list of restrooms by updated date is successful
     Failure/Error: get "api/v1/restrooms/by_date", updated: true,  day: Date.today.day, month: Date.today.month, year: Date.today.year
     URI::InvalidURIError:
       bad URI(is not URI?): http://www.example.com:80api/v1/restrooms/by_date
     # ./spec/api/v1/restrooms_spec.rb:181:in `block (4 levels) in <top (required)>'

```