### PR TITLE
Give hover and focus states another color for better accessibility

### DIFF
--- a/app/assets/stylesheets/nav.css.scss
+++ b/app/assets/stylesheets/nav.css.scss
@@ -10,6 +10,9 @@
     &:hover {
       color: white;
     }
+    &:focus {
+      color: $light-purple;
+    }
   }
 
   ul.navbar-nav > li > a {

--- a/app/assets/stylesheets/nav.css.scss
+++ b/app/assets/stylesheets/nav.css.scss
@@ -8,15 +8,15 @@
   .navbar-brand {
     color: white;
     &:hover {
-      color: white
+      color: white;
     }
   }
 
   ul.navbar-nav > li > a {
     font-size: 10pt;
     color: white;
-    &:hover {
-      color: white
+    &:hover, &:focus {
+      color: $light-purple;
     }
   }
 


### PR DESCRIPTION
Fix for https://github.com/RefugeRestrooms/refugerestrooms/issues/247

- Added an on `focus` color to the navbar links so that it's no longer an unreadable color on focus.
- Updated the navbar links `hover` and `focus` color to be not white for better accessibility.
- Added missing semicolons to be consistent with rest of file.