### PR TITLE
Remove on/off text from the Map/List view button

### DIFF
--- a/app/views/restrooms/index.html.haml
+++ b/app/views/restrooms/index.html.haml
@@ -12,7 +12,7 @@
           %input{:type => "checkbox"}
           %i.fa.fa-child
 
-      .map-toggle-btn.mapToggle.filter.linkbutton.btn-light-purple
+      .map-toggle-btn.mapToggle.linkbutton.btn-lg.btn-light-purple
         Map View
 
 .restrooms-index-content


### PR DESCRIPTION
The Map View and List View toggle has a training `off`. This should resolve https://github.com/RefugeRestrooms/refugerestrooms/issues/277.