### PR TITLE
Fix for vagrant rake task bundler conflicts

### DIFF
--- a/.rake/vagrant.rb
+++ b/.rake/vagrant.rb
@@ -1,9 +1,14 @@
-vagrant_path = 'PATH=/home/vagrant/.rbenv/shims:$PATH'
-
 namespace :vagrant do
   task :shell, [:command] do |_t, args|
     fail "Usage rake vagrant:shell[command]" unless args[:command]
-    sh "vagrant ssh -c 'cd /vagrant/ &&"\
-       "#{vagrant_path} bundle exec #{args[:command]}'"
+
+    vagrant_path = 'PATH=/home/vagrant/.rbenv/shims:$PATH'
+
+    # We need to reset RUBYLIB in order to use gems in
+    # the context of the VM.
+    #
+    # Please see: https://github.com/mitchellh/vagrant/issues/6158#issuecomment-135796049
+    # for more info.
+    sh "unset RUBYLIB; vagrant ssh -c 'cd /vagrant/ && #{vagrant_path} bundle exec #{args[:command]}'"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,5 +410,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock (~> 1.18.0)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/setup/setup_vagrant.sh
+++ b/setup/setup_vagrant.sh
@@ -62,13 +62,21 @@ else
   rbenv install $ruby_version
 fi
 
+# Set local ruby version
+rbenv local $ruby_version
+
 # Install bundle reqs
 cd $REFUGE_PATH
-if which bundle; then
+if which bundle | grep 1.12.15; then
   echo 'bundler installed, skipping'
 else
   echo 'Installing bundler...'
-  gem install bundler --no-rdoc --no-ri -q
+
+  # We must target a specific version of bundler
+  # which is specified in vagrant.gemspec.
+  # File found here: https://github.com/mitchellh/vagrant/blob/a4c7bb822873924619f95edc9baee654fb3d6f1f/vagrant.gemspec#L23
+  # Please see https://github.com/mitchellh/vagrant/issues/7193#issuecomment-204309088 for info
+  gem install bundler -v 1.12.5 --no-rdoc --no-ri -q
 fi
 echo 'Running bundle install...'
 bundle install --gemfile=$REFUGE_PATH/Gemfile


### PR DESCRIPTION
#### Description:
`rake vagrant:shell` was failing for some users because of conflicting bundler versions. This PR addresses that to allow the rake task to run under vagrants gemset/gems instead of a local users.

#### Changes:
- Added command to unset `RUBYLIB` per info [here](https://github.com/mitchellh/vagrant/issues/6158#issuecomment-135796049)
- Sets the ruby version on vagrant setup
- Installs a specific version of bundler (as [required](https://github.com/mitchellh/vagrant/issues/7193#issuecomment-204309088) by vagrant)