### PR TITLE
Fix "guess my location" button's results, makes them relevent to user's location

### DIFF
--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -48,6 +48,7 @@ class Refuge.Restrooms.NewRestroomForm
       type: 'GET'
       url: '/restrooms'
       data:
+        search: true
         nearby: true
         lat: coords.lat
         long: coords.long


### PR DESCRIPTION
# Context
- Fixes #295 
- Needed to add "search: true" as part of search query, or else nearby restroom results will be semi-random and have nothing to do with the user's actual location.

#### Needs Testing
I cannot test this properly, because on my machine the nearby restrooms results generally do not show up after pressing "Guess my location." That happens regardless of the change here. It might have something to do with the Google Maps API key issue. 
Since @mi-wood has the develop branch running at http://refuge-production.herokuapp.com, I am hoping this is easy for @mi-wood or someone with access to that codebase to test.

I was still able to test it, sort of, as can be seen in the screenshots. This is proof of concept only, but logically I think my change should work, just as it does in the URLs I posted in the screenshot section. I have done my best to get as close as possible to testing this the real way.

#### Background, Longer explanation of change

First the "guess my location" button grabs a user's latitude / longitude from the browser's geolocation API. Then it uses the lat-long pair from the Browser's geolocation API to query our restroom database. As of whenever #295 started happening, this pre-programmed query has been getting garbage data as its response. By adding "search: true" as part of the query, we should get real restrooms that are actually near the user. This fix is demonstrated by the URLs in the screenshot section, which are the results from actual queries the button used to make (before) and what it should make now (after).

# Summary of Changes

- added "search: true" as part of the search query (**needs to be tested before merging!**)

# Checklist

- [N/A] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ 🛇 ] CI Passes (Note: unrelated CI failure)
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots
## Before / After
![before & after query fix](https://cloud.githubusercontent.com/assets/20157115/24595637/61b650f4-1806-11e7-9abd-14d25951d2f0.png)

#### Tested using these URLs:
Before: http://refuge-production.herokuapp.com/restrooms?utf8=✓&lat=37.733795&long=-122.446747&nearby=true

After: http://refuge-production.herokuapp.com/restrooms?utf8=✓&lat=37.733795&long=-122.446747&nearby=true&search=true
respectively. 

The difference between search results at these two URLs simulates the effect of this PR. Magenta coloring in the screenshot is from doing Ctrl+F "San Francisco"; magenta coloring will not show up on the site. Lat & long is the same for each URL, points to the middle of San Francisco.)