### PR TITLE
use default vagrant sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,6 @@ https://www.vagrantup.com/downloads.html
         * To start the rails server use: `rails s -b 0.0.0.0`. 
         * Navigate to `localhost:3000`
 
-  * To sync local changes with the vagrant machine, you can run `vagrant rsync-auto` while developing
-
   [1] You can run any command locally using `rake vagrant:shell[]` and it will be executed in the repo root of the vagrant machine. You can try `rake vagrant:shell['pwd']` and see it will print the directory that the repo is in on the vagrant machine!
 
 ### 4 Optional tasks:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,10 +26,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Default value: false
   # config.ssh.forward_agent = true
 
-  # Share refuge repo in vagrant home folder
-  config.vm.synced_folder ".", "/vagrant/", type: "rsync",
-    rsync__exclude: ".bundle"
-
   # View virtualbox provider docs for more options
   config.vm.provider "virtualbox" do |vb|
     vb.name = BOXNAME


### PR DESCRIPTION
# Context
- Fixes #299
- Use default Vagrant sync

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [x] Added Documentation (Service and Code when required)