### PR TITLE
Restore margin-bottom to search bar in headers

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -13,16 +13,10 @@
 }
 
 .header {
-
-    .search-container {
-        margin-bottom: 5px;
-    }
-
     .navbar-toggle:hover {
         background-color: $light-purple;
         border-color: $light-purple
     }
-
 }
 
 


### PR DESCRIPTION
# Context
- More purple space under the search bar, in headers. Only affects pages besides the homepage.
- Reverts part of this commit here: https://github.com/RefugeRestrooms/refugerestrooms/pull/281/commits/dc0aa11520eaf6fa8ee6453893fd00458efbe515
- This is an extremely minor and small change.

# Summary of Changes

- Deleted a css rule that reduced margin-bottom from 10px to 5px on the search bar within headers
    - Home/splash page has search outside of header, and is unchanged

# Checklist

- [x] Tested Mobile Responsiveness
- [N/A] Added Unit Tests
- [N/A] CI Passes (unrelated build failure, see comment below)
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [N/A] Added Documentation (Service and Code when required)

# Screenshots

## Before
![screen shot before with small margin](https://cloud.githubusercontent.com/assets/20157115/25111098/f17eb206-23b6-11e7-89cb-80ad297901ee.png)

## After
![screen shot after with larger margin](https://cloud.githubusercontent.com/assets/20157115/25111100/f5776e20-23b6-11e7-8c50-3bcd62c7202f.png)