### PR TITLE
Remove sensor parameter from Google Maps API calls.

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -31,7 +31,7 @@ function getPoint(string, callback){
 
 
 		//google Geocoding API
-		var url = "http://maps.googleapis.com/maps/api/geocode/json?address=" + string.replace(" ", "+") + "&sensor=false";
+		var url = "http://maps.googleapis.com/maps/api/geocode/json?address=" + string.replace(" ", "+");
 		$.get( url, function( data ) {
 			if(data && data.results){
 				if(data.results.length > 0){

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -3,17 +3,17 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 Before do |scenario|
   # guess in Oakland
-  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?language=en&latlng=37.8044,-122.2708&sensor=false").
+  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?language=en&latlng=37.8044,-122.2708").
     with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
     to_return(:status => 200, :body => File.new("#{Rails.root}/spec/fixtures/guess_in_oakland.json"), :headers => {})
 
   # guess in Winnipeg
-  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?language=en&latlng=49.8975494,-97.140118&sensor=false").
+  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?language=en&latlng=49.8975494,-97.140118").
     with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
     to_return(:status => 200, :body => File.new("#{Rails.root}/spec/fixtures/guess_in_winnipeg.json"), :headers => {})
 
   # guess in Vancouver
-  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?language=en&latlng=49.281006,-123.089959&sensor=false").
+  stub_request(:get, "http://maps.googleapis.com/maps/api/geocode/json?language=en&latlng=49.281006,-123.089959").
     with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
     to_return(:status => 200, :body => File.new("#{Rails.root}/spec/fixtures/guess_in_vancouver.json"), :headers => {})
 


### PR DESCRIPTION
This parameter is deprecated. See:

https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

Removing it prevents a couple of warnings
in the JavaScript console of web browsers.

# Context
- Not affecting our site, because it's just a warning, but it's been reported a couple of times (incidentally, by people debugging the API Key problem). See: #297, #263
- I notice this was mostly dealt with already, here: https://github.com/RefugeRestrooms/refugerestrooms/commit/d72f618e2ab3c25d3a0b58a8927a1548e19426a6

# Summary of Changes

- remove `&sensor=false` from `maps.js`
- remove `&sensor=false` from `webmock.rb`
# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
