### PR TITLE
add reply_to to mailform

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -20,7 +20,8 @@ class Contact < MailForm::Base
     {
       :subject => "My Contact Form #{restroom_id}",
       :to => "refugerestrooms@gmail.com",
-      :from => %("#{name}" <#{email}>)
+      :from => %("#{name}" <#{email}>), # :from overriden by google smtp config
+      :reply_to => %("#{name}" <#{email}>)
     }
   end
 end


### PR DESCRIPTION
# Context
- Fixes #346
- adding reply-to to make responding to emails easier

# Summary of Changes

- add 'reply-to' to mailform contact
- note that google smtp settings are overriding the 'from'

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
