### PR TITLE
Align icons in restroom list to the right

### DIFF
--- a/app/assets/stylesheets/restrooms.scss
+++ b/app/assets/stylesheets/restrooms.scss
@@ -55,7 +55,7 @@
         text-align: right;
         font-size: 15px;
         font-family: Arial;
-        padding: 5px;
+        padding: 5px 0;
     }
     .itemRating {
         width: 150px;
@@ -74,15 +74,18 @@
     .itemExtraInfo {
         position: absolute;
         top: 20px;
-        right: 15px;
+        right: 10px;
+        text-align: right;
     }
     .unisexRestroom {
         width: 45px;
         height: 43px;
+        display: inline-block;
     }
     .ADARestroom {
         width: 44px;
         height: 47px;
+        display: inline-block;
     }
     .unisexRestroom img, .ADARestroom img {
         width: 100%;


### PR DESCRIPTION
# Context
- Fixes #320
- Icons were aligned against distance text length and not uniform between listings.

# Summary of Changes

- Align icons and distance text to the right
- Display icons inline-block

# Screenshots

## Before
![screen shot 2017-06-28 at 3 29 59 pm](https://user-images.githubusercontent.com/5015020/27663331-b2649d18-5c16-11e7-99f9-836815140384.png)
## After
![screen shot 2017-06-28 at 3 28 49 pm](https://user-images.githubusercontent.com/5015020/27663317-9b056a3a-5c16-11e7-9288-220bcbadf066.png)


