### PR TITLE
Preview geolocation when adding new restrooms

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -268,4 +268,10 @@ $(function(){
 	if($map.length > 0) {
 		initMap($map.data('latitude'), $map.data('longitude'), showMarkerImage);
 	}
+
+	window.Maps = {
+		reloadMap: function(map) {
+			initMap(map.dataset.latitude, map.dataset.longitude, showMarkerImage);
+		}
+	}
 });

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -7,12 +7,15 @@ class Refuge.Restrooms.NewRestroomForm
     @_guessButton = @_form.find('.guess-btn')
     @_nearbyContainer = $('.nearby-container')
     @_form_container = $('.new-restrooms-form-container')
+    @_previewButton = @_form.find('.preview-btn')
+    @_map = @_form.find('#mapArea')[0]
 
     # Initialization Methods
     @_bindEvents()
 
   _bindEvents: =>
     @_bindGuessButton()
+    @_bindPreviewButton()
 
   _bindGuessButton: =>
     @_guessButton.click (event) =>
@@ -28,6 +31,27 @@ class Refuge.Restrooms.NewRestroomForm
               console.log data
               $('.form-container').html(data).hide().fadeIn()
               @_requestNearbyRestrooms(coords)
+
+
+  _bindPreviewButton: =>
+    @_previewButton.click (event) =>
+      form = @_form[0]
+      name = form.elements.restroom_name.value
+      street = form.elements.restroom_street.value
+      city = form.elements.restroom_city.value
+      state = form.elements.restroom_state.value
+      country = form.elements.restroom_country.value
+      address = "#{name}, #{street}, #{city}, #{state}, #{country}"
+
+      # Obtain coordinates
+      @_geocoder.geocodeSearchString(address).then (coords) =>
+        @_updateMap(coords)
+
+
+  _updateMap: (coords) =>
+    @_map.dataset.latitude = coords.lat
+    @_map.dataset.longitude = coords.long
+    Maps.reloadMap(@_map)
 
 
   _getNewForm: (coords) =>

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -31,6 +31,7 @@ class Refuge.Restrooms.NewRestroomForm
               console.log data
               $('.form-container').html(data).hide().fadeIn()
               @_requestNearbyRestrooms(coords)
+              @_updateMap(coords)
 
 
   _bindPreviewButton: =>

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -36,6 +36,9 @@ class Refuge.Restrooms.NewRestroomForm
 
   _bindPreviewButton: =>
     @_previewButton.click (event) =>
+      # Show map
+      @_map.classList.remove("hidden")
+
       form = @_form[0]
       name = form.elements.restroom_name.value
       street = form.elements.restroom_street.value

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -8,7 +8,7 @@
       %i.fa.fa-refresh.fa-spin
 
   / Add map for preview
-  %div#mapArea.hidden{ data: { latitude: 38.904735, longitude: -77.033812 } }
+  #mapArea.hidden{ data: { latitude: 38.904735, longitude: -77.033812 } }
 
   .nearby-container.footroom
     // Content of nearby restrooms gets rendered here.

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -7,6 +7,9 @@
       = t('restroom.guess_location')
       %i.fa.fa-refresh.fa-spin
 
+  / Add map for preview
+  %div#mapArea{ data: { latitude: 38.904735, longitude: -77.033812 } }
+
   .nearby-container.footroom
     // Content of nearby restrooms gets rendered here.
 
@@ -22,4 +25,8 @@
   = f.input :changing_table, :collection => [[t('restroom.changing_table'), true], [t('restroom.no_changing_table'), false]], :include_blank => false
   = f.input :directions, :placeholder => t('restroom.directions_hint'), :as => :text, :required => false, :input_html => { :class => "span6" }
   = f.input :comment, :placeholder => t('restroom.comments_hint'), :as => :text, :required => false, :input_html => { :class => "span6" }
+
+  / Click to preview location
+  %button{type: 'button', class: 'preview-btn linkbutton'}
+    = t('restroom.preview')
   = f.button :submit, t('restroom.restsubmit'), :class => "linkbutton"

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -8,7 +8,7 @@
       %i.fa.fa-refresh.fa-spin
 
   / Add map for preview
-  %div#mapArea{ data: { latitude: 38.904735, longitude: -77.033812 } }
+  %div#mapArea.hidden{ data: { latitude: 38.904735, longitude: -77.033812 } }
 
   .nearby-container.footroom
     // Content of nearby restrooms gets rendered here.

--- a/config/locales/restroom.en.yml
+++ b/config/locales/restroom.en.yml
@@ -12,6 +12,7 @@ en:
 
   restroom:
     add_new: 'Submit a restroom to our database'
+    preview: 'Preview'
     required: '* marks required field'
     guess_location: 'Guess current location'
     directions: 'Directions'

--- a/features/preview.feature
+++ b/features/preview.feature
@@ -1,0 +1,7 @@
+@javascript
+Feature: Preview a restroom's location
+
+  Scenario: Preview a restroom before submitting
+    Given I have filled out the address information
+    When I click the preview button
+    Then I should see the map preview

--- a/features/step_definitions/preview_steps.rb
+++ b/features/step_definitions/preview_steps.rb
@@ -9,7 +9,7 @@ Given(/^I have filled out the address information$/) do
 end
 
 When(/^I click the preview button$/) do
-  find_button("Preview").trigger('click')
+  click_button "Preview"
 end
 
 Then(/^I should see the map preview$/) do

--- a/features/step_definitions/preview_steps.rb
+++ b/features/step_definitions/preview_steps.rb
@@ -1,0 +1,17 @@
+Given(/^I have filled out the address information$/) do
+  visit "/"
+  click_link "Submit a New Restroom"
+  fill_in "restroom[name]", with: "Vancouver restroom"
+  fill_in "restroom[street]", with: "684 East Hastings"
+  fill_in "restroom[city]", with: "Vancouver"
+  fill_in "restroom[state]", with: "British Columbia"
+  find(:select, "Country").first(:option, "Canada").select_option
+end
+
+When(/^I click the preview button$/) do
+  find_button("Preview").trigger('click')
+end
+
+Then(/^I should see the map preview$/) do
+  expect(page).to have_css("div#mapArea", :visible => true)
+end


### PR DESCRIPTION
# Context
- Fixes #314
- Add a map for previewing when submitting new restrooms.

# Summary of Changes

- Add preview map.
- Add function to reload a map according to its `data-lattitude` and `data-longitude` properties. (`window.Maps.reloadMap`) I don't know if this is the best way to do this, so if anyone has any suggestions, feel free to make changes.
- When the preview button is clicked, the information from the form will be used to geolocate the restroom and update the map.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

Top:
![image](https://user-images.githubusercontent.com/11802391/29244716-5523641e-7f8d-11e7-801b-677200f01ef9.png)

Bottom:
![image](https://user-images.githubusercontent.com/11802391/29244717-5dbe2aa0-7f8d-11e7-9241-3feb2478c9aa.png)

## After

Top:
![image](https://user-images.githubusercontent.com/11802391/29244724-7e285d24-7f8d-11e7-9857-37c1405ff0fd.png)

Bottom:
![image](https://user-images.githubusercontent.com/11802391/29244720-6ea515e0-7f8d-11e7-8f99-ee98748fc2fe.png)

Hi. I'm Jason. I think this is a really great project. Thank you all for your work. Hope I can contribute more. Also, how do I write tests for this?