### PR TITLE
Fix preview not loading after pressing guess button

### DIFF
--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -30,6 +30,7 @@ class Refuge.Restrooms.NewRestroomForm
             @_getNewForm(coords).then (data, textStatus) =>
               console.log data
               $('.form-container').html(data).hide().fadeIn()
+              @_rebind()
               @_requestNearbyRestrooms(coords)
               @_updateMap(coords)
 
@@ -47,6 +48,17 @@ class Refuge.Restrooms.NewRestroomForm
       # Obtain coordinates
       @_geocoder.geocodeSearchString(address).then (coords) =>
         @_updateMap(coords)
+
+
+  _rebind: =>
+    @_map = $("#mapArea").get(0)
+    @_previewButton = $(".preview-btn")
+    @_guessButton = $(".guess-btn")
+
+    @_bindEvents()
+
+    # Rebind form
+    @_form = $('form.simple_form')
 
 
   _updateMap: (coords) =>

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -36,9 +36,6 @@ class Refuge.Restrooms.NewRestroomForm
 
   _bindPreviewButton: =>
     @_previewButton.click (event) =>
-      # Show map
-      @_map.classList.remove("hidden")
-
       form = @_form[0]
       name = form.elements.restroom_name.value
       street = form.elements.restroom_street.value
@@ -53,6 +50,9 @@ class Refuge.Restrooms.NewRestroomForm
 
 
   _updateMap: (coords) =>
+    # Show map
+    @_map.classList.remove("hidden")
+
     @_map.dataset.latitude = coords.lat
     @_map.dataset.longitude = coords.long
     Maps.reloadMap(@_map)


### PR DESCRIPTION
# Context
- Fixes #366
- Make preview load when guessing location as well. Also fix clicking guess button disabling preview button.

# Summary of Changes

- Move code that unhides the map to the updateMap function, so that it gets called when the guess button is clicked too.
- Add rebind function. See explanation in [commit message](https://github.com/RefugeRestrooms/refugerestrooms/commit/797f45e49a3ac88cd09b1b957c46729b200685d5). This fixes not being able to click the guess button twice, and that clicking the guess button disables the preview button.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)
