### PR TITLE
Fix reverse_geocoding not filling in country selector in form

### DIFF
--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -28,7 +28,7 @@ class Restroom < ApplicationRecord
       obj.street  = geo.address.split(',').first
       obj.city    = geo.city
       obj.state   = geo.state
-      obj.country = geo.country
+      obj.country = geo.country_code
     end
   end
 


### PR DESCRIPTION
# Context
- Fixes #372 
- This sets country property to the `country_code` returned by the geocoder instead of the `country` attribute. The `country_code` corresponds to the values of the options of the country selector.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/11802391/30032150-315f943a-9162-11e7-9c70-423c8a846fe2.png)

## After
![image](https://user-images.githubusercontent.com/11802391/30032163-40ddbff4-9162-11e7-8ce1-5cc97124f1d2.png)
