### PR TITLE
Drag and drop map marker when submitting new restroom

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -4,7 +4,7 @@ function initMap(x, y, image, draggable, callback){
 	image = typeof image !== 'undefined' ? image : currentLocationImage;
 
 	// Draggable defaults to false
-	draggable = (draggable === undefined) ? false : true;
+	draggable =  draggable || false;
 
 	//init map
   var mapOptions = {

--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -1,7 +1,10 @@
 var map;
 
-function initMap(x, y, image){
+function initMap(x, y, image, draggable, callback){
 	image = typeof image !== 'undefined' ? image : currentLocationImage;
+
+	// Draggable defaults to false
+	draggable = (draggable === undefined) ? false : true;
 
 	//init map
   var mapOptions = {
@@ -21,9 +24,12 @@ function initMap(x, y, image){
 
   var currentLocation = new google.maps.Marker({
 	  position: myLatLng,
+	  draggable: draggable,
 	  map: map,
 	  icon: image
   });
+
+  currentLocation.addListener("dragend", callback);
 }
 
 
@@ -272,6 +278,10 @@ $(function(){
 	window.Maps = {
 		reloadMap: function(map) {
 			initMap(map.dataset.latitude, map.dataset.longitude, showMarkerImage);
+		},
+
+		reloadDraggable: function(map, callback) {
+		  initMap(map.dataset.latitude, map.dataset.longitude, showMarkerImage, true, callback);
 		}
 	}
 });

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -29,9 +29,7 @@ class Refuge.Restrooms.NewRestroomForm
             console.log result[0]
             @_getNewForm(coords).then (data, textStatus) =>
               console.log data
-              $('.form-container').html(data).hide().fadeIn()
-              @_requestNearbyRestrooms(coords)
-              @_updateMap(coords)
+              @_updateForm(coords, data, textStatus)
 
 
   _bindPreviewButton: =>
@@ -70,6 +68,10 @@ class Refuge.Restrooms.NewRestroomForm
       success: (data, textStatus) ->
         # $('.new-restrooms-form-container').html(data)
 
+  _updateForm: (coords, data, textStatus) =>
+    $('.form-container').html(data).hide().fadeIn()
+    @_requestNearbyRestrooms(coords)
+    @_updateMap(coords)
 
   _requestNearbyRestrooms: (coords) ->
     $.ajax

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -65,8 +65,6 @@ class Refuge.Restrooms.NewRestroomForm
         restroom:
           latitude: coords.lat
           longitude: coords.long
-      success: (data, textStatus) ->
-        # $('.new-restrooms-form-container').html(data)
 
   _updateForm: (coords, data, textStatus) =>
     $('.form-container').html(data).hide().fadeIn()

--- a/app/assets/javascripts/views/restrooms/new.coffee
+++ b/app/assets/javascripts/views/restrooms/new.coffee
@@ -53,8 +53,15 @@ class Refuge.Restrooms.NewRestroomForm
   _updateMap: (coords) =>
     @_map.dataset.latitude = coords.lat
     @_map.dataset.longitude = coords.long
-    Maps.reloadMap(@_map)
+    Maps.reloadDraggable(@_map, @_onDrag)
 
+  # Callback for map marker 'dragend' event
+  _onDrag: (event) =>
+    coords =
+      lat: event.latLng.lat(),
+      long: event.latLng.lng()
+    @_getNewForm(coords).then (data, textStatus) =>
+      @_updateForm(coords, data, textStatus)
 
   _getNewForm: (coords) =>
     $.ajax


### PR DESCRIPTION
# Context
- Mentioned in #249 and #251.
- Users can now drag the map marker to the desired location in the map preview, and the form will be updated with the new address obtained by reverse geocoding the coordinates of the marker.

Note: the map will disappear after dragging the marker once without my changes in #369.

# Summary of Changes

- Modify `initMap()` to take the arguments `draggable` and `callback`, which make the map marker draggable. `draggable` defaults to `false`. This can also be useful for potential editing functionalities.
- Add `window.Maps.reloadDraggable(map, callback)`, which can be used to update a map with draggable markers.
- Put the code for updating the form in the `_updateForm` method, as the same code gets called multiple times.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots
<img width="1172" alt="drag" src="https://user-images.githubusercontent.com/11802391/30033724-f6d145c6-916a-11e7-80a4-382448c5d7c0.png">
