### PR TITLE
Label search buttons for screen readers

### DIFF
--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -7,7 +7,7 @@
     .input-group
       = text_field_tag :search, params[:search], class: "form-control search-bar"
       .input-group-btn
-        %button.btn.btn-light-purple.submit-search-button{type: "button", title: "Search", value: "Search"}
+        %button.btn.btn-light-purple.submit-search-button{type: "button", title: "Search", value: "Search", aria: { label: "Search" }}
           %i.fa.fa-search.fa-2x
           %i.fa.fa-refresh.fa-spin.fa-2x
         %button.btn.btn-light-purple.current-location-button{type: "button", title: "Search by Current Location", value: (splash ? "Search Current Location" : nil ) }

--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -10,6 +10,6 @@
         %button.btn.btn-light-purple.submit-search-button{type: "button", title: "Search", value: "Search", aria: { label: "Search" }}
           %i.fa.fa-search.fa-2x
           %i.fa.fa-refresh.fa-spin.fa-2x
-        %button.btn.btn-light-purple.current-location-button{type: "button", title: "Search by Current Location", value: (splash ? "Search Current Location" : nil ) }
+        %button.btn.btn-light-purple.current-location-button{type: "button", title: "Search by Current Location", aria: { label: "Search by Current Location" }, value: (splash ? "Search Current Location" : nil ) }
           %i.fa.fa-location-arrow.fa-2x
           %i.fa.fa-refresh.fa-spin.fa-2x


### PR DESCRIPTION
# Context
- Fixes #378 
- This PR adds `aria-label` which seems to be the proper way to make a button's label visible to screen readers. This is confirmed by [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Labeling_buttons) and [several](https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/) [articles](https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-label). 

# Summary of Changes

- Added `aria-label` property to the Search button on the homepage.
- Added `aria-label` property to the Search by location button on the homepage. 

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

I'm including here screenshots from the [WAVE evaluation tool](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US) which is a Chrome extension that evaluates a site for accessibility.

## Before
<img width="1552" alt="screen shot 2017-10-31 at 10 31 07 pm" src="https://user-images.githubusercontent.com/16547949/32257385-3883e4e0-be8b-11e7-8a42-10d2a34ff213.png">

## After
<img width="1552" alt="screen shot 2017-10-31 at 10 32 43 pm" src="https://user-images.githubusercontent.com/16547949/32257428-7035403c-be8b-11e7-9218-4870114a326e.png">
