### PR TITLE
Fix text overflow by widening div.navbar-brand (45px -> 16em)

### DIFF
--- a/app/assets/stylesheets/components/nav.scss
+++ b/app/assets/stylesheets/components/nav.scss
@@ -5,6 +5,7 @@
 
   .navbar-brand {
     color: white;
+    width: 16em;
     padding: 13.5px 60px;
     &:hover {
       color: white;


### PR DESCRIPTION
# Context
- Fixes #379 
- Tidies up a bit after #377 (aka #268)

# Summary of Changes
- Added some width to `.navbar-brand` so that the "Refuge Restrooms" text doesn't overflow to two lines.
- It's only one (short) line of css.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
![screen shot 2017-11-03 at 18 51 42](https://user-images.githubusercontent.com/20157115/32399582-7dea9396-c0cd-11e7-97df-eb7119a560d0.png)

## After
![screen shot 2017-11-03 at 18 52 36](https://user-images.githubusercontent.com/20157115/32399586-80706744-c0cd-11e7-9306-8de5a373c2af.png)
