### PR TITLE
Use suggested workaround to fix VO for older iOS

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -19,7 +19,7 @@
 
   .row.even-more-headroom
     .col-xs-12.col-sm-6.col-sm-offset-3
-      = link_to image_tag("app-store.svg"), "https://itunes.apple.com/us/app/refuge-restrooms/id968531953?mt=8"
+      = link_to image_tag("app-store.svg", role: "img"), "https://itunes.apple.com/us/app/refuge-restrooms/id968531953?mt=8"
 
   .row.more-headroom.splash-bottom-padding
     .col-xs-12.col-sm-6.col-sm-offset-3


### PR DESCRIPTION
# Context
- Fixes #384.
- As @DeeDeeG said in #384, a [webkit bug](https://bugs.webkit.org/show_bug.cgi?id=145263) in devices with older iOS (before 10?) prevents Safari from focusing on the App Store button in VoiceOver mode. I used the suggested workaround from the discussion on the bug page, which is to include a `role="img"` property on the image tag.

@DeeDeeG Can you help me test this? I've deployed the change to https://jason-refuge-staging.herokuapp.com/