### PR TITLE
Bump bugnag version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     bourbon (4.3.4)
       sass (~> 3.4)
       thor (~> 0.19)
-    bugsnag (5.4.1)
+    bugsnag (6.1.0)
     builder (3.2.3)
     capybara (2.15.4)
       addressable


### PR DESCRIPTION
Doesn't appear to have any breaking changes, but do please test against my tests. I didn't see anything, neither did my CI.

# Context
- Bumps bugsnag to 6.1.0