### PR TITLE
Set piwik to use async tracking in production

### DIFF
--- a/config/piwik.yml
+++ b/config/piwik.yml
@@ -13,7 +13,7 @@ production:
   piwik:
     id_site: 2
     url: analytics.enspiral.info
-    use_async: false
+    use_async: true
     disabled: false
 
 development:


### PR DESCRIPTION
This prevents the tracking script from blocking the loading of other scripts, such as the Google Maps Autocomplete script. Now, autocomplete is available right when the page loads.

Compare the difference between https://refugerestrooms.org and https://jason-refuge-staging.herokuapp.com (where async tracking has been enabled).

# Context
- Fixes #394.
- Set Piwik to use asynchronous tracking.

# Screenshots

## Before
<img width="945" alt="screen shot 2017-12-05 at 9 57 44 pm" src="https://user-images.githubusercontent.com/11802391/33642359-a9059f00-da07-11e7-82d4-f1c302ea7868.png">

## After
![image](https://user-images.githubusercontent.com/11802391/33642368-b43ea5c4-da07-11e7-8774-e115b3cdb708.png)
