### PR TITLE
#401 Fix Footer being cut off

### DIFF
--- a/app/assets/stylesheets/pages/splash.scss
+++ b/app/assets/stylesheets/pages/splash.scss
@@ -27,8 +27,7 @@ body {
     bottom: 0px;
     left: 0px;
     right: 0px;
-    margin-bottom: 0px;
-    height: 60px;
+    margin-bottom: 25px;
     a {
       color: white;
       text-decoration: underline;


### PR DESCRIPTION
# Context
- Fixes #401
- Footer had a hard coded height on it, and no bottom margin, this fixes that. 

# Summary of Changes

- Adjust CSS

# Checklist

- [x] Tested Mobile Responsiveness
- [n/a] Added Unit Tests
- [x] CI Passes
- [x] Deploys to Heroku on test Correctly (Maintainers will handle)
- [n/a] Added Documentation (Service and Code when required)

# Screenshots

## Before
![footer is cut off](https://user-images.githubusercontent.com/5265597/34232766-b50843c6-e596-11e7-9c7e-06d2d29ec522.png)

## After
![screen shot 2017-12-20 at 3 08 11 pm](https://user-images.githubusercontent.com/5265597/34232968-b5a7bb3a-e597-11e7-8307-f394d6d8d8b3.png)
