### PR TITLE
contributing.md: Add a step to install VirtualBox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,10 @@
 ### 2 Install Vagrant.
 https://www.vagrantup.com/downloads.html
 
-### 3 Capture the powers of vagrant
+### 3 Install VirtualBox
+https://www.virtualbox.org/wiki/Downloads
+
+### 4 Capture the powers of vagrant
   * In the repo dir: <code>vagrant up</code> (Safely ignore: 'dpkg-preconfigure: unable to re-open stdin: No such file or directory')
   * If changes have been made since running vagrant up: <code>vagrant provision</code>
   
@@ -25,10 +28,10 @@ https://www.vagrantup.com/downloads.html
 
   [1] You can run any command locally using `rake vagrant:shell[]` and it will be executed in the repo root of the vagrant machine. You can try `rake vagrant:shell['pwd']` and see it will print the directory that the repo is in on the vagrant machine!
 
-### 4 Optional tasks:
+### 5 Optional tasks:
 run <code>rake db:fix_accents</code> to clean up encoding problems in the safe2pee data. (Use <code>rake db:fix_accents[dry_run]</code> to preview the changes.)
 
-### 5 Assets
+### 6 Assets
 * [Assets Repo](https://github.com/RefugeRestrooms/refuge_assets)
 
 ## Testing


### PR DESCRIPTION
# Context
- Gets new users past an error message in Vagrant about needing a "[provider](https://www.vagrantup.com/docs/providers/)" (i.e. VirtualBox).

> No usable default provider could be found for your system.
> 
> Vagrant relies on interactions with 3rd party systems, known as
> "providers", to provide Vagrant with resources to run development
> environments. Examples are VirtualBox, VMware, Hyper-V.
> 
> The easiest solution to this message is to install VirtualBox, which
> is available for free on all major platforms.
> 
> If you believe you already have a provider available, make sure it
> is properly installed and configured. You can see more details about
> why a particular provider isn't working by forcing usage with
> `vagrant up --provider=PROVIDER`, which should give you a more specific
> error message for that particular provider.
> 

# Summary of Changes

- Updates `CONTRIBUTING.md` to have a step telling folks to install VirtualBox.

# Checklist

- [N/A] Tested Mobile Responsiveness
- [N/A] Added Unit Tests
- [Probably] CI Passes
- [N/A] Deploys to Heroku on test Correctly (Maintainers will handle)
- [x] Added Documentation (Service and Code when required)

# Screenshots

## Before

![contributing-before](https://user-images.githubusercontent.com/20157115/34265438-e04080e6-e643-11e7-8b8a-99348699be8e.png)

## After

![contributing-after](https://user-images.githubusercontent.com/20157115/34265443-e6c5db46-e643-11e7-8fe6-f898cfb2427e.png)