### PR TITLE
Adds unit tests to check that there are ARIA labels on the search buttons

### DIFF
--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -7,7 +7,7 @@
     .input-group
       = text_field_tag :search, params[:search], class: "form-control search-bar"
       .input-group-btn
-        %button.btn.btn-light-purple.submit-search-button{type: "button", title: "Search", value: "Search"}
+        %button.btn.btn-light-purple.submit-search-button{type: "button", title: "Search", value: "Search", aria: { label: "Search" }}
           %i.fa.fa-search.fa-2x
           %i.fa.fa-refresh.fa-spin.fa-2x
         %button.btn.btn-light-purple.current-location-button{type: "button", title: "Search by Current Location", value: (splash ? "Search Current Location" : nil ) }

--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -10,6 +10,6 @@
         %button.btn.btn-light-purple.submit-search-button{type: "button", title: "Search", value: "Search", aria: { label: "Search" }}
           %i.fa.fa-search.fa-2x
           %i.fa.fa-refresh.fa-spin.fa-2x
-        %button.btn.btn-light-purple.current-location-button{type: "button", title: "Search by Current Location", value: (splash ? "Search Current Location" : nil ) }
+        %button.btn.btn-light-purple.current-location-button{type: "button", title: "Search by Current Location", aria: { label: "Search by Current Location" }, value: (splash ? "Search Current Location" : nil ) }
           %i.fa.fa-location-arrow.fa-2x
           %i.fa.fa-refresh.fa-spin.fa-2x

--- a/features/search.feature
+++ b/features/search.feature
@@ -13,9 +13,14 @@ Feature: Search for restrooms
     And I search from Vancouver
     Then I should not see a restroom
 
+  Scenario: Search from splash page (screen reader accessibility check)
+    When I am on the splash page
+    Then the search buttons should have ARIA labels
+
   Scenario: Map display
     Given a restroom exists in Winnipeg
     When I am on the splash page
     And I search from Winnipeg
     And I show the map
     Then I should see a restroom on the map
+

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -7,3 +7,8 @@ When(/^I search from (.*?)$/) do |location|
   mock_location location
   find('.current-location-button').click
 end
+
+Then(/^the search buttons should have ARIA labels$/) do
+ expect(find('button.submit-search-button')['aria-label']).to be_truthy
+ expect(find('button.current-location-button')['aria-label']).to be_truthy
+end


### PR DESCRIPTION
# Context
- Fixes #378
- Expanding on work by @hectorsector in PR #383 by adding unit tests

# Summary of Changes

- Adds a test to `search.feature` and `search_steps.rb`
  -  The test checks that the value of search buttons' `aria-label` HTML attribute is non-empty.

# Checklist

- [N/A] Tested Mobile Responsiveness
- [x] Added Unit Tests
- [x] CI Passes
- [x] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![old_tests_w_drawn_on_highlights_2](https://user-images.githubusercontent.com/20157115/34366396-df9f4752-ea68-11e7-8009-a50d935bd635.png)

## After

![passing_new_test_highlights_2 0](https://user-images.githubusercontent.com/20157115/34362497-43e12856-ea42-11e7-9a1a-8a39176edcc7.png)