### PR TITLE
Set locale based on Accept-Language header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'high_voltage', '~> 3.0.0'
 gem 'bugsnag'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'rack-jsonp'
+gem 'http_accept_language'
 
 # Upgraded to 1.0.0 for Rails 5.1.4
 gem 'activeadmin', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
       activesupport (>= 4.1, < 5.2)
     hashie (3.5.6)
     high_voltage (3.0.0)
+    http_accept_language (2.1.1)
     i18n (0.8.6)
     i18n_data (0.8.0)
     ice_nine (0.11.2)
@@ -407,6 +408,7 @@ DEPENDENCIES
   grape-swagger (~> 0.7.2)
   haml
   high_voltage (~> 3.0.0)
+  http_accept_language
   jbuilder (~> 2.5)
   jquery-rails
   kaminari (~> 0.17.0)
@@ -436,4 +438,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,12 @@ class ApplicationController < ActionController::Base
 
   private
     def extract_locale_from_accept_language_header
-      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
+      accept_language = request.env['HTTP_ACCEPT_LANGUAGE']
+      if accept_language.nil?
+        "en"
+      else
+        request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
+      end
     end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,17 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
    def set_locale
-     I18n.locale = extract_locale_from_accept_language_header
+     I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
    end
-
-  private
-    def extract_locale_from_accept_language_header
-      accept_language = request.env['HTTP_ACCEPT_LANGUAGE']
-      if accept_language.nil?
-        "en"
-      else
-        request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
-      end
-    end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,23 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :mobile_filter_header
+  before_action :set_locale
 
   def mobile_filter_header
     @mobile = true
   end
+
+  def mobile_filter_header
+    @mobile = true
+  end
+
+   def set_locale
+     I18n.locale = extract_locale_from_accept_language_header
+   end
+
+  private
+    def extract_locale_from_accept_language_header
+      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
+    end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
    def set_locale
-     I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
+     I18n.locale = http_accept_language.language_region_compatible_from(I18n.available_locales)
    end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,9 @@ module SaferstallsRails
         resource "/api/*", headers: :any, methods: [:get, :post, :options]
       end
     end
+
+    # I18n stuff
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module SaferstallsRails
 
     # I18n stuff
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.available_locales = [:en]
 
   end
 end


### PR DESCRIPTION
This used to be Intimaria#1.

# Context
- A solution to language switching discussed in #413.

# Summary of Changes

- Set locale based on the Accept-Langauge header of the request, which is usually set by the browser. According to the [rails guide on i18n](http://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests)

> The Accept-Language HTTP header indicates the preferred language for request's response. Browsers set this header value based on the user's language preference settings, making it a good first choice when inferring a locale.

Now, the language of the page will change to fit with the preferred language setting of the browser.

## Change Setting
Chrome Settings
![image](https://user-images.githubusercontent.com/11802391/34802994-b6a80596-f63e-11e7-83e4-5892fa045bc2.png)
<img width="1280" alt="screen shot 2018-01-10 at 6 28 37 pm" src="https://user-images.githubusercontent.com/11802391/34800982-2dcd8d86-f634-11e7-9021-602c37c04e39.png">