### PR TITLE
Implement correct editing behavior

### DIFF
--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -86,6 +86,7 @@ private
 
   def permitted_params
     params.require(:restroom).permit(
+      :edit_id,
       :name,
       :street,
       :city,

--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -16,7 +16,6 @@ class RestroomsController < ApplicationController
     if params[:edit_id]
       @restroom = find_restroom
       @restroom.edit_id = params[:edit_id]
-      @restroom.id = Restroom.last.id + 1
     elsif params[:guess]
       @restroom = Restroom.new(permitted_params)
       @restroom.reverse_geocode
@@ -32,13 +31,14 @@ class RestroomsController < ApplicationController
     if @restroom.spam?
       flash[:notice] = I18n.t('restroom.flash.spam')
       render 'new'
-    elsif @restroom.save 
+    elsif @restroom.save
       if @restroom.edit_id != nil && @restroom.edit_id != 0
         flash[:notice] = I18n.t('restroom.flash.edit', name: @restroom.name)
+        redirect_to Restroom.find(@restroom.edit_id)
       else
         flash[:notice] = I18n.t('restroom.flash.new', name: @restroom.name)
+        redirect_to @restroom
       end
-      redirect_to Restroom.find(params[:id])
     else
       display_errors
       render 'new'

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -1,6 +1,6 @@
 %h1= t('restroom.add_new')
 
-= simple_form_for @restroom, html: {class: 'submit-new-bathroom-form form-vertical'} do |f|
+= simple_form_for @restroom, :url => restrooms_path, :method => :post, html: {class: 'submit-new-bathroom-form form-vertical'} do |f|
   %h5= t('restroom.required')
   .clearfix
     %button.btn.btn-light-purple.guess-btn{:type => "button", :value => t('restroom.guess_location')}

--- a/app/views/restrooms/_formsubmit.html.haml
+++ b/app/views/restrooms/_formsubmit.html.haml
@@ -20,6 +20,7 @@
   = f.input :country, priority: ["United States", "Canada", "United Kingdom"], :required => true, input_html: {class: 'form-control'}
   = f.hidden_field :latitude
   = f.hidden_field :longitude
+  = f.hidden_field :edit_id
   = f.input :accessible, :collection => [[t('restroom.accessible'), true], [t('restroom.not_accessible'), false]], :include_blank => false
   = f.input :unisex, :collection => [[t('restroom.type.unisex'), true], [t('restroom.type.single_stall'), false]], :include_blank => false
   = f.input :changing_table, :collection => [[t('restroom.changing_table'), true], [t('restroom.no_changing_table'), false]], :include_blank => false


### PR DESCRIPTION
# Context
- Fix issues encountered during #414.
- My changes make it so that editing a bathroom correctly submits to the `create` method of the restroom controller, and redirects to the original bathroom page. For details see my commit messages.

# Screenshots

![image](https://user-images.githubusercontent.com/11802391/34913621-5575ca9e-f8d0-11e7-90ab-d7e6b3dd6a45.png)

