### PR TITLE
Make poltergeist able to show debug web inspector

### DIFF
--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -1,2 +1,7 @@
 require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, :inspector => true)
+end
+
+Capybara.javascript_driver = :poltergeist_debug


### PR DESCRIPTION
With the poltergeist_debug driver, you can now put `page.driver.debug` in the cucumber step definitions and capybara will pause when it gets to the line and open a web inspector window of the tests in which you can see the errors.

In the opened browser page, click the bottom of the two links to get to a web inspector hooked up to the tests. Click the "console" tab to see any javascript errors. Click on the line number and you will be taken to the source javascript file with the line producing the error highlighted. Although, because of rails, all the javascript files are bundled into one giant file so it will take a while to load.

The inspector makes debugging the tests easier.

# Context
- Part of #433.

# Summary of Changes
- Change Capybara's javascript driver to poltergeist with the option `:inspector => true`.

# Screenshots
![image](https://user-images.githubusercontent.com/11802391/35485860-37f364f4-0433-11e8-9299-750e20f28354.png)

![image](https://user-images.githubusercontent.com/11802391/35485818-d14dc71c-0432-11e8-904d-6ba5ec6099e5.png)
