### PR TITLE
.gitattributes: Unix-ify line-endings for Docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+setup/entry text eol=lf


### PR DESCRIPTION
# Context
- Fixes an issue when using Docker on Windows.
  - Docker doesn't undestand the `entry` script if the file is checked out with Windows-style line endings (`CR-LF`), which is how Git checks the file out by default on Windows. Setup errors out. Changing this fixes the error.

# Summary of Changes
- Uses a `.gitattributes` file to configure the `setup/entry` file to always have Unix-style line-endings (`LF`).

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)