### PR TITLE
Add Code Climate integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
 script:
   - docker-compose run -e "RAILS_ENV=test" web rake db:test:prepare spec
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --prefix /refugerestrooms

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=c18df080592f9c99ca8080a6d5e052aa5fd3964044a0fe0b71e48f8e18998dc2
 language: ruby
 services: docker
 before_install:
   - docker-compose build
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - docker-compose run -e "RAILS_ENV=test" web rake db:test:prepare spec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@ Production CI: [![Build Status](https://travis-ci.org/RefugeRestrooms/refugerest
 
 Develop CI: [![Build Status](https://travis-ci.org/RefugeRestrooms/refugerestrooms.svg?branch=develop)](https://travis-ci.org/RefugeRestrooms/refugerestrooms)
 
+Code Climate: [![Maintainability](https://api.codeclimate.com/v1/badges/a641d46a4ad2c2f01932/maintainability)](https://codeclimate.com/github/RefugeRestrooms/refugerestrooms/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/a641d46a4ad2c2f01932/test_coverage)](https://codeclimate.com/github/RefugeRestrooms/refugerestrooms/test_coverage)
 
-[![Stories in Ready](https://badge.waffle.io/RefugeRestrooms/refugerestrooms.png?label=ready)](https://waffle.io/RefugeRestrooms/refugerestrooms)
+
+Waffle.io: [![Stories in Ready](https://badge.waffle.io/RefugeRestrooms/refugerestrooms.png?label=ready)](https://waffle.io/RefugeRestrooms/refugerestrooms)
 # REFUGE restrooms
 
 Providing safe restroom access to transgender, intersex, and gender nonconforming individuals.


### PR DESCRIPTION
# Context
- Adds Code Climate integration and badges

# Summary of Changes

- Adds a few code climate test reporting integration steps to the Travis CI config
- Require `simplecov` at the beginning of the Cucumber `env.rb` file
- Adds two badges to README.md

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
![readme.md-before](https://user-images.githubusercontent.com/20157115/36048063-f986439e-0dab-11e8-8437-5c9013993de8.PNG)

## After

![readme.md-after-showing-working-status-badges](https://user-images.githubusercontent.com/20157115/41322242-f2739c7a-6e75-11e8-9254-83686fa4cbb0.png)

