### PR TITLE
Add chromium and set up X11 socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ WORKDIR /refugerestrooms
 COPY Gemfile /refugerestrooms/Gemfile
 COPY Gemfile.lock /refugerestrooms/Gemfile.lock
 RUN bundle install
+RUN apt-get install -y chromium
 COPY . /refugerestrooms

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
     image: postgres
   web:
     build: .
+    privileged: true
     entrypoint: [setup/entry]
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
       - .:/refugerestrooms
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    environment:
+      - DISPLAY
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
This didn't work on my machine, but it should as long the X11 server on the host is allowing connections from the docker container. This involves using 'xhost' to specify permissions.

You'll need XQuartz if you're on a Mac, or Cygwin/X if you're on Windows.

# Context
- #458

# Summary of Changes

- Attach host X11 socket (`/tmp/.X11-unix`) to container.
- Expose environmental variable `DISPLAY` to container.