### PR TITLE
simple_form.fr.yml: Revert key names to English

### DIFF
--- a/config/locales/fr/simple_form.fr.yml
+++ b/config/locales/fr/simple_form.fr.yml
@@ -3,8 +3,8 @@
 
 fr:
   simple_form:
-    "oui": 'Oui'
-    "non": 'Non'
+    "yes": 'Oui'
+    "no": 'Non'
     required:
       text: 'requis'
       mark: '*'


### PR DESCRIPTION
# Context
- Working on Travis time-outs discussed in #457 and #455
- Changes some key names from French (#450) back to English
  - (Translation `.yml` files consist of a series of `key:value` pairs; keys needn't be translated, only the corresponding value.)
- Even if this doesn't fix Travis errors, might want to consider merging anyway.

# Summary of Changes

- Change `"oui"` key back to `"yes"`
- Change `"non"` key back to `"no"`

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)