### PR TITLE
poltergeist: Increase timeout time

### DIFF
--- a/features/support/poltergeist.rb
+++ b/features/support/poltergeist.rb
@@ -1,7 +1,7 @@
 require 'capybara/poltergeist'
 
 Capybara.register_driver :poltergeist_debug do |app|
-  Capybara::Poltergeist::Driver.new(app, :inspector => true)
+  Capybara::Poltergeist::Driver.new(app, timeout: 60, :inspector => true)
 end
 
 Capybara.javascript_driver = :poltergeist_debug


### PR DESCRIPTION
# Context

- Attempting to fix Poltergeist timeout errors discussed in #457 and #455.

# Summary of Changes

- Increase timeout from default (30 seconds?) to 60 seconds.
  - See https://github.com/teampoltergeist/poltergeist#customization

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)