### PR TITLE
Dockerfile: add step "gem install bundler"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ RUN mkdir /refugerestrooms
 WORKDIR /refugerestrooms
 COPY Gemfile /refugerestrooms/Gemfile
 COPY Gemfile.lock /refugerestrooms/Gemfile.lock
+RUN gem install bundler
 RUN bundle install
 COPY . /refugerestrooms


### PR DESCRIPTION
# Context
Trying to fix poltergeist timeout issues discussed in #457 and #455

# Summary of Changes

- Adds a step to the Dockerfile to do `gem install bundler`. This will get us the latest `bundler` version. As opposed to using the bundler version included in RVM's pre-built Ruby 2.3.1 image. 
  - At the moment, this change means we will go from using bundler 1.13.6 to -> 1.16.1, but we would continue to receive the latest bundler version on an ongoing basis.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)