### PR TITLE
100% FILIPINO TRANSLATION FOR devise.fl.yml FILE

### DIFF
--- a/config/locales/en/devise.fl.yml
+++ b/config/locales/en/devise.fl.yml
@@ -1,0 +1,59 @@
+# Mga karagdagang mga pagsasalin ng salita ay makikita sa https://github.com/plataformatec/devise/wiki/I18n
+
+fil:
+  magbalangkas:
+    mga kompermasyon:
+      confirmed: "Ang iyong account ay matagumpay na nakomperma."
+      send_instructions: "Ikaw ay makakatanggap ng email na may kalakip na mga instruksiyon tungkol sa kung papaano i-komperma ang iyong account sa kakaunting minuto."
+      send_paranoid_instructions: "Kapag ang iyong email address ay umiiral sa aming database, ikaw ay makakatanggap ng email na may kasamang mga instruksiyon kung papaano i-komperma ang iyong account sa kakaunting minuto."
+    nabigo:
+      already_authenticated: "Ika ay ay naka-signed in na."
+      inactive: "Ang iyong account ay hindi pa aktibo."
+      invalid: "Hindi tama ang email o password."
+      locked: "Ang iyong account ay nai-locked."
+      last_attempt: "Mayroon kapang isang subok bago ma-locked ang iyong account."
+      not_found_in_database: "Hindi tama ang email o password."
+      timeout: "Ang sesyon ay natapos na. Kung maaari mag-sign in para makapagpatuloy."
+      unauthenticated: "Kailangan mong mag-sign in o mag-sign up bago magpatuloy."
+      unconfirmed: "Kinakailangan mong magkomperma sa iyong account bago magpatuloy."
+    mailer:
+      confirmation_instructions:
+        subject: "Ang mga instruksiyon para sa kompermasyon"
+      reset_password_instructions:
+        subject: "I-reset ang mga instruksiyon para sa password"
+      unlock_instructions:
+        subject: "I-unlock ang mga Instruksiyon"
+    omniauth_callbacks:
+      failure: "Hindi makapagpatotoo sa iyo mula sa %{kind} dahil sa \"%{reason}\"."
+      success: "Matagumpay na napatotoo mula sa %{kind} account."
+    mga password:
+      no_token: "Hindi ka maka-akses sa pahinang ito kung wala kang password reset mula sa iyong email. Kapag gusto mong baguhin ang password gamit ang email, dapat siguraduhin na gamitin ang buong URL na ibinigay."
+      send_instructions: "Ikaw ay makatanggap ng email na may kalakip na mga tungkol sa kung papaano ma-reset ang iyong password sa iilang minuto."
+      send_paranoid_instructions: "Kapag ang iyung email ay nasa database na namin, ikaw ay makakatanggap ng recovery link sa iyong email address your email address sa iilang minuto."
+      updated: "Ang password mo ay matagumpay na napalitan.Ikaw ngayon ay naka-signed in na."
+      updated_not_active: "Ang iyong password ay matagumpay nang napalitan."
+    mga pagpaparehistro:
+      destroyed: "Paalam! Ang iyong account ay matagumpay na nakansela. Ninanais naming makita kayong muli."
+      signed_up: "Maligayang pagdating! You have signed up successfully."
+      signed_up_but_inactive: "Ikaw ay matagumpay na naka-signed up. Gayunpaman, hindi pa namin kayo mapasign in dahil ang iyong  account ay hindi pa aktibo."
+      signed_up_but_locked: "Ikaw ay matagumpay na naka-signed up. Gayunpaman,, hindi pa namin kayo mapasign in dahil ang iyong  account ay nakalock."
+      signed_up_but_unconfirmed: "Ang mensahi na may kompermasyon sa link ay naipadala na sa iyong email address. Kami ay nakikiusap na buksan ang link para mapagana ang iyong account."
+      update_needs_confirmation: "Ang iyong account ay matagumpay nang na-updeyt, pero kinakailangan pa naming i-verify ang iyong bagong email address. Kami ay nakiki-usap na tingnan ang iyong email at mag-klik sa confirm link para ma-finalize ang pagkomperma sa iyong bagong email address."
+      updated: "Matagumpay mong na-update ang iyong account."
+    mga sesyon:
+      signed_in: "Matagumpay kang naka-signed in."
+      signed_out: "Matagumpay kang naka-signed out."
+    mga unlock:
+      send_instructions: "Ikaw ay makakatanggap ng email namay kalakip na mga instruksiyon tungkol sa kung papaano ma-unlock ang iyong account sa iilang minuto."
+      send_paranoid_instructions: "Kapag ang iyong account ay umiiral, ikaw ay makakatanggap ng email namay kalakip na instruksiyon tungkol sa kung papaano ito ma-unlock sa iilang minuto."
+      unlocked: "Ang iyong account ay matagumpay nang na-unlock. Mag-sign in para makapagpatuloy."
+  mga error:
+    mga mensahe:
+      already_confirmed: "tapos nang nakomperma, maaaring subukang magsign in"
+      confirmation_period_expired: "kailangang ikomperma sa loob ng %{period}, maaaring magbigay ng bagong rekwest"
+      expired: "has expired, please request a new one"
+      not_found: "hindi makita"
+      not_locked: "hindi nakalocked"
+      not_saved:
+        one: "may 1 error na nagbabawal sa %{resource} para mai-save:"
+        other: "%{count} may mga errors na nagbabawal sa %{resource} para mai-save:"


### PR DESCRIPTION
Hi. This is my complete translation for devise.fl.yml file with 59 strings.

# Context
I have translated 100% for devise.en.yml to devise.fil.yml (Filipino Words).

# Summary of Changes
100% translation from 1-59 strings.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
# Context
I have translated devise.en.yml to devise.fil.yml (Filipino Words).

# Summary of Changes
Completely translated 60 lines of devise.en.yml into Filipino language.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/35182720/36207087-acb8b632-11cf-11e8-8573-c749108eccb2.png)

## After
![image](https://user-images.githubusercontent.com/35182720/36204830-ae449a3c-11c7-11e8-87b1-1f4171e73b6f.png)
