### PR TITLE
Hide changing table icon in minimal lists

### DIFF
--- a/app/assets/stylesheets/restrooms/main.scss
+++ b/app/assets/stylesheets/restrooms/main.scss
@@ -144,7 +144,7 @@
         clear: both;
         padding: 5px 0;
         border-width: 0;
-        .listItemImage, .itemRating, .unisexRestroom, .ADARestroom {
+        .listItemImage, .itemRating, .unisexRestroom, .ADARestroom, .changingTable {
             display: none;
         }
         .itemInfo, .itemName, .itemStreet, .itemExtraInfo, .itemDistance {


### PR DESCRIPTION
For example, in a list of nearby restrooms, both the gender neutral and accessibility icons are hidden while changing table icon still shows. Stumbled upon this when converting Coffeescript files.

# Context
- Add the changing table icon class to the list of things to be hidden in a `.minimalRestroomList`.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
<img width="1174" alt="screen shot 2018-03-13 at 6 16 04 pm" src="https://user-images.githubusercontent.com/11802391/37373061-60a50d8c-26eb-11e8-8979-1b548d8c708f.png">
