### PR TITLE
Add links to code of conduct from Readme and Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,5 @@ Please cover any new code with specs. We prefer code to be covered using RSpec o
 
 ## Now What?
 Checkout our [Wiki](https://github.com/RefugeRestrooms/refugerestrooms/wiki) and specifically the [newcomers guide](https://github.com/RefugeRestrooms/refugerestrooms/wiki/Maintainers'-Manual-%5C--Newcomers'-Guide).
+
+Please also read our [Code of Conduct](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CODE_OF_CONDUCT.md), which gives guidance on our standards of community and interaction. These are designed to keep things constructive, respectful and welcoming for all the people who contribute to our project. It also explains how/where to direct any complaints about unwelcome behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,4 +45,4 @@ Please cover any new code with specs. We prefer code to be covered using RSpec o
 ## Now What?
 Checkout our [Wiki](https://github.com/RefugeRestrooms/refugerestrooms/wiki) and specifically the [newcomers guide](https://github.com/RefugeRestrooms/refugerestrooms/wiki/Maintainers'-Manual-%5C--Newcomers'-Guide).
 
-Please also read our [Code of Conduct](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CODE_OF_CONDUCT.md), which gives guidance on our standards of community and interaction. These are designed to keep things constructive, respectful and welcoming for all the people who contribute to our project. It also explains how/where to direct any complaints about unwelcome behavior.
+Please also read our [Code of Conduct](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CODE_OF_CONDUCT.md), which gives guidance on our standards of community and interaction.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For more information on how to contribute to Refuge Restrooms, or how the techno
 
 If you just want to get your environment set up for making changes locally and testing, you can head directly to [CONTRIBUTING.md](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CONTRIBUTING.md).
 
+See also our [Code of Conduct](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CODE_OF_CONDUCT.md) for our standards of community, and who is responsible for enforcement, and where to direct complaints.
+
 ## Tech
 
 * Ruby Version - ruby-2.3.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information on how to contribute to Refuge Restrooms, or how the techno
 
 If you just want to get your environment set up for making changes locally and testing, you can head directly to [CONTRIBUTING.md](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CONTRIBUTING.md).
 
-See also our [Code of Conduct](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CODE_OF_CONDUCT.md) for our standards of community, and who is responsible for enforcement, and where to direct complaints.
+Please also read our [Code of Conduct](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/CODE_OF_CONDUCT.md), which gives guidance on our standards of community and interaction.
 
 ## Tech
 


### PR DESCRIPTION
# Context
- Follow-up to #490 
- Adds links to `CODE_OF_CONDUCT.md` from `README.md` and `CONTRIBUTING.md`

# Summary of Changes

- `CONTRIBUTING.md` now has a link to the code of conduct, and a paragraph explaining what the code of conduct is about.
- `README.md` now has a link to the code of conduct, and a sentence mentioning what the code of conduct is about.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)