### PR TITLE
CONTRIBUTING.md: Instructions for all platforms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,12 @@
 https://help.github.com/articles/fork-a-repo/
 
 ### 2 Install Docker.
-https://docs.docker.com/install/
+- **Windows 10:** https://store.docker.com/editions/community/docker-ce-desktop-windows
+- **macOS El Capitan 10.11 and newer:** https://store.docker.com/editions/community/docker-ce-desktop-mac
+
+_(Older Mac or Windows PC? See [instructions for Docker Toolbox](https://github.com/RefugeRestrooms/refugerestrooms/wiki/How-to-use-Docker-Toolbox-with-Refuge-Restrooms).)_
+
+_(Running Linux? See [instructions for Docker CE on Linux](https://github.com/RefugeRestrooms/refugerestrooms/wiki/How-to-use-Docker-CE-on-Linux-with-Refuge-Restrooms).)_
 
 ### 3 Build the Docker Container
 Build the container from any [terminal](https://github.com/RefugeRestrooms/refugerestrooms/wiki/What-is-a-Terminal-(or-%22Terminal-Emulator%22)%3F-How-do-I-run-text-based-commands-on-my-computer%3F) program with:


### PR DESCRIPTION
Commit message:

> Updated the Docker download links on CONTRIBUTING.md
> to lead more directly to an actual "Download Docker" button for each platform.
> 
> (Applies to 'Docker for Windows' and 'Docker for Mac' editions,
> which are for recent hardware/OS combos only.)
> 
> Also link to the "Docker Toolbox" and "Docker CE for Linux" guides in the Wiki.
> (Covers older Windows and Mac computers, or Linux computers, respectively.)

# Context
- Gives proper instructions for all platforms and Docker versions, as discussed once on Slack.

# Summary of Changes

- Include better (more-direct) download links for Docker for Windows and Docker for Mac
- Link to the Wiki pages recently created to document how to use Docker Toolbox and Docker CE for Linux

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [x] Added Documentation (Service and Code when required)