### PR TITLE
Replace ruby base-image in Dockerfile with slimmer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM ruby:2.3.7
+FROM ruby:2.3.7-slim
 ENV PHANTOM_JS=2.1.1
+
+# Add basic binaries and clean up the apt cache
+RUN apt-get update \
+  && apt-get install -y bzip2 curl gnupg wget \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add the apt repository for yarn
 RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM ruby:2.3.7-slim
 ENV PHANTOM_JS=2.1.1
 
-# Add basic binaries and clean up the apt cache
+# Add basic binaries
 RUN apt-get update \
-  && apt-get install -y bzip2 curl gnupg wget \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y bzip2 curl gnupg wget
 
 # Add the apt repository for yarn
 RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
@@ -24,6 +23,10 @@ RUN apt-get install build-essential chrpath libssl-dev libxft-dev -y && \
   mv $PHANTOM_JS /usr/local/share && \
   ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin && \
   apt-get install -y yarn
+
+# Clean up the apt cache
+RUN rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /refugerestrooms
 WORKDIR /refugerestrooms
 


### PR DESCRIPTION
# Context
- Fixes #[issueNumber]
- Replaced ruby base-image (which was heavy at 941 MB) with a slimmer base-image (just 254 MB)

# Summary of Changes

- Used a slimmer base image which has a footprint of only 254 MB (faster deploy times, across cloud)
- Since slimmer base image missed some packages required during "docker build", added lines to Dockerfile to install basic binaries

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

Tests passed:
```
$ docker-compose run -e "RAILS_ENV=test" web rake db:test:prepare spec
Creating network "refugerestrooms_default" with the default driver
Creating refugerestrooms_db_1 ... done
Created database ‘bathrooms_test'
..
..
..
Randomized with seed 54156
.....................................Puma starting in single mode...
* Version 3.11.2 (ruby 2.3.7-p456), codename: Love Song
* Min threads: 0, max threads: 1
* Environment: test
* Listening on tcp://0.0.0.0:39645
Use Ctrl-C to stop
...................

Finished in 23.82 seconds (files took 8.49 seconds to load)
56 examples, 0 failures

Randomized with seed 54156

Coverage report generated for RSpec to /refugerestrooms/coverage. 541 / 594 LOC (91.08%) covered.
```

# Screenshots
Could launch application after the changes:
![image](https://user-images.githubusercontent.com/102387/46485401-78d1ff80-c7b0-11e8-8dca-d8c21ebdd3c4.png)

## Before
With the previous base-image, host machine had a 941 MB Ruby base image.

## After
With these changes, the Ruby base image footprint on host is just 254 MB.
