### PR TITLE
Fix empty restrooms db during development

### DIFF
--- a/setup/entry
+++ b/setup/entry
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-rake db:create
-rake db:migrate
+bundle exec rake db:setup
 
 exec "$@"

--- a/setup/entry
+++ b/setup/entry
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-bundle exec rake db:setup
+rails db:setup
 
 exec "$@"


### PR DESCRIPTION
Fixes db being empty during development.
Ensures restroom entries from `db/export.csv` are loaded.

# Context
- Copied the `bundle exec rake db:setup` command from the old [Vagrant configurations](https://github.com/RefugeRestrooms/refugerestrooms/blob/18ae19aeace01aa082cf548ae0818e490609f24e/setup/setup_vagrant.sh#L99).
- Makes it easier to test search and API pages
- Documentation/ reference:
  - This Stack Overflow answer: https://stackoverflow.com/questions/10301794/difference-between-rake-dbmigrate-dbreset-and-dbschemaload
  - The source code for these db functions: https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/railties/databases.rake 

# Summary of Changes

- Remove `db:create` and `db:migrate` commands in `setup/entry`
- Replace with `bundle exec rake db:setup`

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![Restrooms search results showing no results and a mostly blank page](https://user-images.githubusercontent.com/20157115/46622553-11da8080-caf9-11e8-9df6-f7e4728eb65e.png)


## After

![Restrooms search results showing full page of restroom entries](https://user-images.githubusercontent.com/20157115/46622513-e9528680-caf8-11e8-9652-1a536f40343d.png)
