### PR TITLE
_head.html.haml: Update Maps API version

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -6,7 +6,7 @@
 %meta{:content => "RefugeRestrooms.org", :name => "author"}/
 %meta{:content => "initial-scale=1, maximum-scale=1", :name => "viewport"}/
 
-%script{:src => "https://maps.googleapis.com/maps/api/js?v=3.31&libraries=places&key=AIzaSyBXcCrqzMlm-ZmtNQve7AuipNdE4vySUF0"}
+%script{:src => "https://maps.googleapis.com/maps/api/js?v=quarterly&libraries=places&key=AIzaSyBXcCrqzMlm-ZmtNQve7AuipNdE4vySUF0"}
 = stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
 = javascript_pack_tag "application", "data-turbolinks-track": "reload"
 = csrf_meta_tags


### PR DESCRIPTION
commit message:

> v3.31 is deprecated.
> 
> This also updates to the new weekly/quartery versioning scheme.
> See: https://developers.google.com/maps/documentation/javascript/versions

# Context
- The version of the Maps API we're using is deprecated, so it should be updated.
- We can stay up to date by using either `quarterly` or`weekly` as the version number.
  - See: https://developers.google.com/maps/documentation/javascript/versions
  - Versions such as `v3.34` are still usable, but it would be nice to never be out of date without having to worry about manual updates, in my opinion.
- There's release notes for all the versions of the Maps API here: https://developers.google.com/maps/documentation/javascript/releases

# Summary of Changes

- Changes our api version from `v3.31` to `quarterly`.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
