### PR TITLE
Docker: Don't geocode the db seed entries

### DIFF
--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -79,6 +79,7 @@ class Restroom < ApplicationRecord
 
     def perform_geocoding
       return true if Rails.env == "test"
+      return true if ENV["SEEDING_DONT_GEOCODE"]
       geocode
     end
 end

--- a/setup/entry
+++ b/setup/entry
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
-rails db:setup
+# Set up the database for development, and seed with placeholder data from `db/export.csv`
+SEEDING_DONT_GEOCODE="true" rails db:setup
 
 exec "$@"


### PR DESCRIPTION
Commit message:

> They are already geocoded and do not need to be sent to the Maps API.
> 
> This saves quota usage, and prevents error messages when we are over quota limit.

# Context
- Fixes #512
- Avoid geocoding the `db/export.csv` restroom entries, since they're already geocoded, and because this saves quota usage.

# Summary of Changes

- Set a `SEEDING-DONT-GEOCODE` environment variable to "true" during the `setup/entry` Docker entry script
- Update `app/models/restroom.rb` to check for the `SEEDING-DONT-GEOCODE` environment variable and not geocode if that is set to "true"

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![before, showing database creation and lots of geocoding errors during server startup](https://user-images.githubusercontent.com/20157115/46883888-44e68200-ce21-11e8-8764-fcbb907bf75c.png)

## After

![after, showing database creation without errors during server startup](https://user-images.githubusercontent.com/20157115/46883919-59c31580-ce21-11e8-8f65-976bdf0d249a.png)
