### PR TITLE
Optimize Travis CI build speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
     - CC_TEST_REPORTER_ID=c18df080592f9c99ca8080a6d5e052aa5fd3964044a0fe0b71e48f8e18998dc2
 language: ruby
 services: docker
-before_install:
+install:
   - docker-compose build
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Commit message: 

> Moves `docker-compose build`
> from the `before_install:` step to the `install:` step
> in Travis CI.
> 
> This overrides the default `install:` step for Ruby apps,
> which is `bundle install --jobs=3 --retry=3`.
> 
> In doing so, we avoid running `bundle install` twice:
> - Once inside the Docker container (good)
> - Again outside of the container (unnecessary)
> 
> (The `bundle install` outside of the Docker container
> would have no bearing on our web app, tests, etc...
> but it would make Travis CI take longer to build the branch.)
> 
> See:
> https://docs.travis-ci.com/user/customizing-the-build/#the-build-lifecycle
> https://docs.travis-ci.com/user/customizing-the-build/#customizing-the-installation-step
> https://docs.travis-ci.com/user/customizing-the-build/#breaking-the-build
> 
> https://docs.travis-ci.com/user/languages/ruby#dependency-management

# Context
- Shortens Travis CI runs
  - Avoids running `bundle install` outside of the Docker container (where it has has no bearing on our app)

# Summary of Changes
- Overrides default `install` step:
  - Moves `docker-compose build` to the `install` step instead of `before_install`.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
![before-travis](https://user-images.githubusercontent.com/20157115/46910710-14810f80-cf17-11e8-8cd2-7efe4fd51605.png)

## After
![after-travis](https://user-images.githubusercontent.com/20157115/46910711-1c40b400-cf17-11e8-9509-b4bd96cca372.png)