### PR TITLE
Store reverse geo-coded address & force unique addresses

### DIFF
--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -18,9 +18,10 @@ class Restroom < ApplicationRecord
   ignoring: :accents
 
   validates :name, :street, :city, :state, presence: true
+  validates :street, uniqueness: {scope: [:city, :state], message: "is already registered"}
 
   geocoded_by :full_address
-  after_validation :perform_geocoding, :reverse_geocode
+  before_validation :perform_geocoding, :reverse_geocode
 
   reverse_geocoded_by :latitude, :longitude do |obj, results|
     if geo = results.first

--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -21,7 +21,8 @@ class Restroom < ApplicationRecord
   validates :street, uniqueness: {scope: [:city, :state], message: "is already registered"}
 
   geocoded_by :full_address
-  before_validation :perform_geocoding, :reverse_geocode
+  before_validation :perform_geocoding, if: ->(obj){ obj.full_address.present? }
+  before_validation :reverse_geocode, if: ->(obj){ obj.full_address.present? }
 
   reverse_geocoded_by :latitude, :longitude do |obj, results|
     if geo = results.first

--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -20,11 +20,10 @@ class Restroom < ApplicationRecord
   validates :name, :street, :city, :state, presence: true
 
   geocoded_by :full_address
-  after_validation :perform_geocoding
+  after_validation :perform_geocoding, :reverse_geocode
 
   reverse_geocoded_by :latitude, :longitude do |obj, results|
     if geo = results.first
-      obj.name    = geo.address
       obj.street  = geo.address.split(',').first
       obj.city    = geo.city
       obj.state   = geo.state

--- a/lib/tasks/reverse_geocode.rake
+++ b/lib/tasks/reverse_geocode.rake
@@ -1,0 +1,26 @@
+namespace :db do
+  desc "Reverse geocode each restroom's address (use db:reverse_geocode[dry_run] to preview changes)"
+  task :reverse_geocode, [:dry_run] => [:environment] do |t, args|
+    args.with_defaults(dry_run: false)
+
+    if args.dry_run
+      puts "Dry running reverse_geocode"
+    else
+      puts "Running reverse_geocode"
+    end
+
+    puts ""
+
+    Restroom.all.each do |restroom|
+
+      previous = restroom.full_address
+      restroom.reverse_geocode
+
+      if previous != restroom.full_address
+        puts "ID: #{restroom.id}\t#{previous}\n"
+        puts "\t\t\\==> #{restroom.full_address}\n\n"
+        restroom.save unless args.dry_run
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

- Fixes #399

Generally, this makes the data more consistent, however this relies more on the geocode lookup being correct for what the user puts in. It might be a good idea to force the user to preview (via google maps) before they can submit a restroom, or to use a proper address lookup. Thoughts?

# Summary of Changes

Restrooms will now populate the geocode, then set the address fields to the address from a reverse lookup before validation.

The address field must be unique. This is only enforced in the activerecord model & not the database schema, meaning it won't complain about existing records / manually added records.

Added a task that iterates over each restroom and re-populates the address from a reverse geocode lookup (`db:reverse_geocode` / `db:reverse_geocode[dry_run]`)