### PR TITLE
Prevent upvoting or downvoting multiple times on the same restroom

### DIFF
--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -39,9 +39,9 @@ class RestroomsController < ApplicationController
 
   def update
     if params[:restroom][:downvote]
-      Restroom.increment_counter(:downvote, @restroom.id)
+      _vote_for_restroom(:downvote)
     elsif params[:restroom][:upvote]
-      Restroom.increment_counter(:upvote, @restroom.id)
+      _vote_for_restroom(:upvote)
     elsif @restroom.update(permitted_params)
       flash[:notice] = I18n.t('restroom.flash.updated')
     else
@@ -74,6 +74,15 @@ private
 
   def find_restroom
     @restroom = Restroom.find(params[:id])
+  end
+
+  def _vote_for_restroom(up_or_downvote)
+    if session[:voted_for] and session[:voted_for].include? @restroom.id
+      flash[:notice] = I18n.t('restroom.flash.alreadyvoted')
+    else
+      Restroom.increment_counter(up_or_downvote, @restroom.id)
+      session[:voted_for] = session[:voted_for] ? session[:voted_for].push(@restroom.id) : [@restroom.id]
+    end
   end
 
   def permitted_params

--- a/config/locales/en/restroom.en.yml
+++ b/config/locales/en/restroom.en.yml
@@ -45,6 +45,7 @@ en:
       upvotesuccess: 'This restroom has been upvoted! Thank you for contributing to our community.'
       downvoteerror: 'There was an unexpected problem downvoting this post.'
       downvotesuccess: 'This restroom has been downvoted! Thank you for contributing to our community.'
+      alreadyvoted: 'You have already voted for this restroom.'
       new: 'A new restroom entry has been created for %{name}.'
       updated: 'This restroom entry has been updated'
       deleted: 'This restroom entry has been deleted'

--- a/config/locales/es/restroom.es.yml
+++ b/config/locales/es/restroom.es.yml
@@ -45,6 +45,7 @@ es:
       upvotesuccess: '¡Este baño se ha calificado en positivo! Gracias por contribuir a nuestra comunidad.'
       downvoteerror: 'Se generó un problema inesperado con su calificación negativa.'
       downvotesuccess: '¡Este baño se ha calificado en negativo! Gracias por contribuir a nuestra comunidad.'
+      alreadyvoted: 'Ya calificó a este baño.'
       new: 'Una nueva entrada de baño se ha creado para %{name}.'
       updated: 'Esta entrada de baño ha sido actualizada'
       deleted: 'Esta entrada de baño ha sido borrada'

--- a/spec/controllers/restrooms_controller_spec.rb
+++ b/spec/controllers/restrooms_controller_spec.rb
@@ -8,10 +8,53 @@ describe RestroomsController, type: :controller do
 
   context "voting" do
     let(:restroom) { FactoryBot.create(:restroom) }
+    let(:post_params_downvote) {
+      {
+        id: restroom.id,
+        restroom: {
+          downvote: true
+        }
+      }
+    }
+    let(:post_params_upvote) {
+      {
+        id: restroom.id,
+        restroom: {
+          upvote: true
+        }
+      }
+    }
 
     it "should downvote" do
+      expect {
+        post :update, params: post_params_downvote
+      }.to change { restroom.reload.downvote }.by 1
+    end
+
+    it "should upvote" do
+      expect {
+        post :update, params: post_params_upvote
+      }.to change { restroom.reload.upvote }.by 1
+    end
+
+    it "shouldn't upvote or downvote twice" do
+      post :update, params: post_params_upvote
+
+      expect {
+        post :update, params: post_params_upvote
+      }.not_to change { restroom.reload.upvote }
+
+      expect {
+        post :update, params: post_params_downvote
+      }.not_to change { restroom.reload.downvote }
+    end
+
+    it "should allow you to vote for multiple restrooms" do
+      session[:voted_for] = [restroom.id]
+      restroom_two = FactoryBot.create(:restroom)
+
       post_params = {
-        id: restroom.id,
+        id: restroom_two.id,
         restroom: {
           downvote: true
         }
@@ -19,20 +62,8 @@ describe RestroomsController, type: :controller do
 
       expect {
         post :update, params: post_params
-      }.to change { restroom.reload.downvote }.by 1
-    end
-
-    it "should upvote" do
-      post_params = {
-        id: restroom.id,
-        restroom: {
-          upvote: true
-        }
-      }
-
-      expect {
-        post :update, params: post_params
-      }.to change { restroom.reload.upvote }.by 1
+      }.to change { restroom_two.reload.downvote }.by 1
+      expect(session[:voted_for]).to match_array([restroom.id, restroom_two.id])
     end
   end
 end


### PR DESCRIPTION
# Context
- Fixes #357 
- Basic prevention of double-voting for a restroom.

# Summary of Changes

- After up- or downvoting a restroom, store that restroom ID in `session` and prevent tallying further votes for that restroom
- Add a flash message in English and Spanish

## Concerns

- I left off Javascript changes to disable the buttons, but I'd be happy to add it in if folks think it would be nice!
- I think we're safe to put database IDs into session since it's encrypted, but if anyone has concerns about leaking information, let me know.

# Checklist

- [x] Tested Mobile Responsiveness
- [x] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## After
<img width="1312" alt="already-voted" src="https://user-images.githubusercontent.com/3465940/47575161-0794f080-d907-11e8-9cef-5267e1345dcd.png">
