### PR TITLE
Adds Brazilian Portuguese (pt-BR) translation

### DIFF
--- a/app/views/restrooms/show.html.haml
+++ b/app/views/restrooms/show.html.haml
@@ -22,7 +22,7 @@
     .col-xs-12
 
       %p
-        %strong #{t('restrooom.directions')}:
+        %strong #{t('restroom.directions')}:
         = @restroom.directions
       %p
         %strong #{t('restroom.comments')}:

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module SaferstallsRails
 
     # I18n stuff
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-    config.i18n.available_locales = [:en, :es, :fr, :pl]
+    config.i18n.available_locales = [:en, :es, :fr, :pl, :"pt-BR"]
     #config.i18n.default_locale = :fr
 
 

--- a/config/locales/pt-BR/about.pt-BR.yml
+++ b/config/locales/pt-BR/about.pt-BR.yml
@@ -1,0 +1,22 @@
+pt-BR:
+  about:
+    title: 'Sobre REFUGE'
+    p1header: 'O que é REFUGE restrooms?'
+    p1:
+      first: 'Refuge Restrooms é uma aplicação web que busca fornecer acesso a banheiros seguros para indivíduos transgêneros, intersexo ou não-conformantes de gênero. Pessoas podem procurar por banheiros por proximidade, adicionar novos lugares e também comentar e avaliar lugares existentes.'
+      second: 'Nossa liderança é trans e buscamos criar uma comunidade focada não apenas em achar acesso a banheiros seguros, mas também advogar pela segurança de pessoas transgêneras, intersexo ou não-conformantes de gênero.'
+    p2header: 'Onde vocês pegaram todos esses dados?'
+    p2: 'As primeiras 4500 entradas são graças ao velho banco de dados Safe2Pee. O resto do nosso banco de dados foi gerado por nossos usuários. Se você conhece um banheiro neutro ou seguro, por favor adicione ao nosso banco de dados!'
+    p3header: 'Por que vocês escolheram o nome REFUGE?'
+    p3: 'Nós acreditamos firmemente que todas as pessoas têm o direito de usar o banheiro com segurança e nós queríamos que o nome da nossa aplicação tivesse um pouco da mesma dignidade que queremos dar aos nossos usuários. Falando de um modo simples, gostaríamos de fornecer um lugar de refúgio na sua necessidade.'
+    p4header: "Qual a importância dos banheiros afinal, e por que precisamos desse recurso?"
+    p4: "Um dos maiores campos de batalha em que a luta por direitos de transgêneros acontece diariamente são os banheiros. Parece que toda semana uma criança transgênera vira o centro de uma notícia nacional porque ela usou um banheiro designado ao gênero com que ela se identificava. No entanto, nós também sabemos que apesar de vitórias legislativas em anos recentes a respeito do uso dos banheiros, muitos indivíduos transgêneros ainda enfrentam assédio verbal e físico simplesmente por usar um banheiro. Ninguém deveria passar por isso - e é por isso que criarmos o REFUGE."
+    p5header: 'O que podemos fazer para ajudar?'
+    p5:
+      first: "<strong>Primeiro:</strong> Adicione lugares. O banco de dados é tão grande quanto quisermos. Quanto mais lugares, mais compreensivo e valioso o recurso vai ser."
+      second: "<strong>Segundo:</strong> Espalhe a palavra. Twitter. Facebook. Tumblr. Blog. O que você usar, use. Faça as pessoas conhecerem este recurso."
+      third: "<strong>Terceiro:</strong> Se você sabe programar, visite o GitHub e informe um bug, sugira uma melhoria, o ainda contribua com um pouco de código e ajude o projeto. REFUGE é código aberto e não podemos fazê-lo sem você."
+      fourth: "<strong>Quarto: </strong> Doe. Fique ligado em uma campanha futura de crowdfunding para financiar alguma tecnologia que precisamos usar e também pagar nossa equipe de design e engenharia com um pouco de dinheiro pelo seu trabalho árduo e incansável. Essas pessoas têm trabalhado de graça para trazer esse serviço para vocês e não queremos que ninguém trabalhe de graça. Muitas pessoas do time principal são transgêneras e com subempregos no momento."
+    p6header: "Por que minha empresa ou organização está listada?"
+    p6: "Descubra mais no nosso <a href='/business_info'>FAQ para empresas</a>!"
+    contribute: 'Faça fork e contribua no GitHub!'

--- a/config/locales/pt-BR/activerecord.pt-BR.yml
+++ b/config/locales/pt-BR/activerecord.pt-BR.yml
@@ -1,0 +1,28 @@
+pt-BR:
+  activerecord:
+    errors:
+      messages:
+        accepted: "deve ser aceito(a)"
+        blank: "deve ser preenchido(a)"
+        confirmation: "não foi confirmado(a) corretamente"
+        date_starting_today: "não pode ser uma data passada"
+        empty: "deve ser preenchido(a)"
+        equal_to: "deve ser igual a %{count}"
+        even: "deve ser par"
+        exclusion: "é reservado(a)"
+        greater_than: "deve ser maior que %{count}"
+        greater_than_or_equal_to: "deve ser maior ou igual a %{count}"
+        inclusion: "não foi preenchido"
+        invalid: "está inválido(a)"
+        less_than: "deve ser menor que %{count}"
+        less_than_or_equal_to: "deve ser menor ou igual a %{count}"
+        not_a_number: "não é um número"
+        not_in_program: "não está no programa %{program}"
+        odd: "deve ser ímpar"
+        overlaps: "está conflitando com outro plano existente"
+        record_invalid: "não é válido"
+        taken: "já está em uso"
+        too_long: "é muito longo(a) (máximo de %{count} caracteres)"
+        too_short: "é muito curto(a) (mínimo de %{count} caracteres)"
+        uniq: "deve ser único(a)"
+        wrong_length: "tem o comprimento errado (deve ter %{count} caracteres)"

--- a/config/locales/pt-BR/business_info.pt-BR.yml
+++ b/config/locales/pt-BR/business_info.pt-BR.yml
@@ -1,0 +1,24 @@
+pt-BR:
+  business_info:
+    title: "Refuge Restrooms - Informações para Empresas"
+    p1header: "1) O que é Refuge Restrooms?"
+    p1: "REFUGE é uma aplicação web que busca fornecer acesso a banheiros seguros para indivíduos transgêneros, intersexo ou não-conformantes de gênero. Leia mais sobre nós na nossa página <a href='/about'>Sobre</a>."
+    p2header: "2) Como meu estabelecimento entrou nesta lista?"
+    p2: "Alguém usou seu banheiro e quis cadastrar seu estabelecimento como recurso. Todos os nossos dados são fornecidos e cadastrados por usuários."
+    p3header: "3) Como posso ser um bom anfitrião?"
+    p3: "Obrigado por perguntar! Frequentemente, visitantes do REFUGE só querem fazer uma parada rápida e seguir seu caminho, assim como qualquer outro visitante, e potencialmente ajudando seu negócio ou estabelecimento enquanto estão lá. Funcionários atenciosos e boas experiências podem ajudar bastante a conquistar simpatia pelo seu negócio ou estabelecimento na seção de avaliações da aplicação (mais sobre isso abaixo!)"
+    p4header: "4) Por que banheiros seguros são um problema?"
+    p4:
+      first: "Usar um banheiro é uma atividade do dia-a-dia que pode ser difícil para pessoas da nossa comunidade -- especialmente visitando áreas fora da sua rotina diária. Aí é que entra o nosso projeto de mapeamento."
+      second: "De acordo com a <a href='http://www.ustranssurvey.org/'>Pesquisa Trans Norteamericana</a>:"
+      list1: "59% das pessoas evitam usar um banheiro por medo de confronto"
+      list2: "31% evitam comer ou beber fora, para evitar ter que usar o banheiro"
+      list3: "24% tiveram sua presença no banheiro questionada"
+      list4: "12% foram assediadas, atacadas ou violentadas sexualmente em um banheiro"
+      list5: "9% tiveram acesso ao banheiro negado"
+      list6: "8% desenvolveram problemas nos rins ou no trato urinário por evitar o uso do banheiro"
+    p5header: "5) O que significa uma avaliação?"
+    p5: "Avaliações ajudam visitantes a compartilhar experiências com outras pessoas sobre um lugar. Nós encorajamos visitantes a compartilhar o máximo de informações possível sobre cada lugar no mapa."
+    p6header: "6) Como posso remover meu cadastro?"
+    p6: "Nós esperamos que você considere manter seu cadastro; ele pode significar muito para a saúde e o bem estar das pessoas. No entanto, se você preferir não ser listado, use o nosso formulário de contato para requisitar a remoção e nosso voluntariado irá trabalhar nisso assim que possível (este é um projeto de código aberto, portanto nosso trabalho é feito voluntariamente)."
+

--- a/config/locales/pt-BR/contacts.pt-BR.yml
+++ b/config/locales/pt-BR/contacts.pt-BR.yml
@@ -3,7 +3,7 @@ pt-BR:
     new:
       request-edit-for-restroom: 'Solicitar alteração para o banheiro %{restroom_name}'
       contact-title: 'Contato'
-      leave-this-field-blank: 'Leave this field blank!'
+      leave-this-field-blank: 'Deixe este campo em branco!'
     submitted:
       thank-you-period: 'Obrigado por sua mensagem.'
       thank-you-exclamation: 'Obrigado por sua mensagem!'

--- a/config/locales/pt-BR/contacts.pt-BR.yml
+++ b/config/locales/pt-BR/contacts.pt-BR.yml
@@ -1,0 +1,11 @@
+pt-BR:
+  contacts:
+    new:
+      request-edit-for-restroom: 'Solicitar alteração para o banheiro %{restroom_name}'
+      contact-title: 'Contato'
+      leave-this-field-blank: 'Leave this field blank!'
+    submitted:
+      thank-you-period: 'Obrigado por sua mensagem.'
+      thank-you-exclamation: 'Obrigado por sua mensagem!'
+      cannot-send: 'Não foi possível enviar a mensagem.'
+      we-will-get-back-to-you: "Entraremos em contato em breve."

--- a/config/locales/pt-BR/devise.pt-BR.yml
+++ b/config/locales/pt-BR/devise.pt-BR.yml
@@ -1,0 +1,64 @@
+# Traduções adicionais em https://github.com/plataformatec/devise/wiki/I18n
+
+pt-BR:
+  devise:
+    confirmations:
+      confirmed: "Sua conta foi confirmada com sucesso."
+      send_instructions: "Você receberá um email com instruções para confirmar sua conta em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de email existir em nosso banco de dados, você receberá um email com instruções para confirmar sua conta em alguns minutos."
+    failure:
+      already_authenticated: "Você já está logado."
+      inactive: "Sua conta ainda não foi ativada."
+      invalid: "%{authentication_keys} ou senha inválida."
+      locked: "Sua conta está bloqueada."
+      last_attempt: "Você tem mais uma tentativa antes de sua conta ser bloqueada."
+      not_found_in_database: "%{authentication_keys} ou senha inválida."
+      timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
+      unauthenticated: "Você precisa entrar ou registrar-se antes de continuar."
+      unconfirmed: "Você precisa confirmar seu endereço de email antes de continuar."
+    mailer:
+      confirmation_instructions:
+        subject: "Instruções de confirmação"
+      reset_password_instructions:
+        subject: "Instruções de redefinição de senha"
+      unlock_instructions:
+        subject: "Instruções de desbloqueio"
+      email_changed:
+        subject: "Email alterado"
+      password_change:
+        subject: "Senha alterada"
+    omniauth_callbacks:
+      failure: "Não foi possível autenticá-lo em %{kind} porque \"%{reason}\"."
+      success: "Autenticado com sucesso em %{kind}."
+    passwords:
+      no_token: "Você não pode acessar esta página para redefinição, por favor tenha certeza de que usou a URL completa recebida."
+      send_instructions: "Você receberá, em breve, um email com instruções de como redefinir sua senha."
+      send_paranoid_instructions: "Se seu endereço de email existir em nosso banco de dados, você receberá um link de redefinição de senha em alguns minutos."
+      updated: "Sua senha foi atualizada com sucesso. Você agora está logado."
+      updated_not_active: "Sua senha foi atualizada com sucesso."
+    registrations:
+      destroyed: "Tchau! Sua conta foi cancelada com êxito. Esperamos ver você de novo em breve!"
+      signed_up: "Bem-vindo! Você se registrou com êxito."
+      signed_up_but_inactive: "Você se registrou com êxito. Entretanto, precisa confirmar sua conta antes de fazer login."
+      signed_up_but_locked: "Você se registrou com sucesso. Entretando, sua conta está bloqueada, e não foi possível fazer login."
+      signed_up_but_unconfirmed: "Uma mensagem com um link de confirmação foi enviada para seu endereço de email. Por favor, siga o link para ativar sua conta."
+      update_needs_confirmation: "Você atualizou sua conta com sucesso, mas nós precisamos verificar seu endereço de email. Por favor, cheque sua caixa de entrada e siga o link recebido."
+      updated: "Sua conta foi atualizada com sucesso."
+    sessions:
+      signed_in: "Logado com sucesso."
+      signed_out: "Saiu com sucesso."
+      already_signed_out: "Saiu com sucesso."
+    unlocks:
+      send_instructions: "Você receberá um email com instruções para desbloquear sua conta em alguns minutos."
+      send_paranoid_instructions: "Se sua conta existir, você receberá um email com instruções para desbloqueá-la em alguns minutos."
+      unlocked: "Sua conta foi desbloqueada com sucesso. Por favor, faça login para continuar."
+  errors:
+    messages:
+      already_confirmed: "já foi confirmado, por favor faça login"
+      confirmation_period_expired: "precisava ser confirmada em %{period}, por favor solicite um novo link"
+      expired: "expirou, por favor solicite uma nova"
+      not_found: "não encontrado"
+      not_locked: "não está bloqueada"
+      not_saved:
+        one: "1 erro impediu que %{resource} fosse salvo(a):"
+        other: "%{count} erros impediram que %{resource} fosse salvo(a):"

--- a/config/locales/pt-BR/devise.pt-BR.yml
+++ b/config/locales/pt-BR/devise.pt-BR.yml
@@ -12,7 +12,7 @@ pt-BR:
       invalid: "%{authentication_keys} ou senha inválida."
       locked: "Sua conta está bloqueada."
       last_attempt: "Você tem mais uma tentativa antes de sua conta ser bloqueada."
-      not_found_in_database: "%{authentication_keys} ou senha inválida."
+      not_found_in_database: 'Não encontrado no banco de dados.'
       timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
       unauthenticated: "Você precisa entrar ou registrar-se antes de continuar."
       unconfirmed: "Você precisa confirmar seu endereço de email antes de continuar."

--- a/config/locales/pt-BR/footer.pt-BR.yml
+++ b/config/locales/pt-BR/footer.pt-BR.yml
@@ -5,7 +5,7 @@ pt-BR:
         github: 'Refuge Restrooms no GitHub'
         twitter: 'Refuge Restrooms no Twitter'
         facebook: 'Refuge Restrooms no Facebook'
-        tumblr: 'Blog do Refuge Restrooms no tumblr'
+        tumblr: 'Blog do Refuge Restrooms no Tumblr'
         email: 'Envie um Email para Refuge Restrooms'
       refuge-restrooms-is-open-source: 'Refuge Restrooms é código aberto.'
       code-on-github: 'Código no GitHub.'

--- a/config/locales/pt-BR/footer.pt-BR.yml
+++ b/config/locales/pt-BR/footer.pt-BR.yml
@@ -10,6 +10,6 @@ pt-BR:
       refuge-restrooms-is-open-source: 'Refuge Restrooms é código aberto.'
       code-on-github: 'Código no GitHub.'
       contribute-to-the-project: 'Contribua com o projeto'
-      on-patreon: 'no patreon.'
+      on-patreon: 'no Patreon.'
       copyleft: 'Copyleft'
       refuge-restrooms: 'Refuge Restrooms.'

--- a/config/locales/pt-BR/footer.pt-BR.yml
+++ b/config/locales/pt-BR/footer.pt-BR.yml
@@ -1,0 +1,15 @@
+pt-BR:
+  layouts:
+    footer:
+      aria-labels:
+        github: 'Refuge Restrooms no GitHub'
+        twitter: 'Refuge Restrooms no Twitter'
+        facebook: 'Refuge Restrooms no Facebook'
+        tumblr: 'Blog do Refuge Restrooms no tumblr'
+        email: 'Envie um Email para Refuge Restrooms'
+      refuge-restrooms-is-open-source: 'Refuge Restrooms é código aberto.'
+      code-on-github: 'Código no GitHub.'
+      contribute-to-the-project: 'Contribua com o projeto'
+      on-patreon: 'no patreon.'
+      copyleft: 'Copyleft'
+      refuge-restrooms: 'Refuge Restrooms.'

--- a/config/locales/pt-BR/navigation.pt-BR.yml
+++ b/config/locales/pt-BR/navigation.pt-BR.yml
@@ -1,0 +1,11 @@
+pt-BR:
+  layouts:
+    navigation:
+      toggle-navigation-button-label: 'Toggle navigation'
+      submit-a-new-restroom-hyperlink-label: 'Cadastrar Banheiro'
+      about-hyperlink-label: 'Sobre'
+      contact-hyperlink-label: 'Contato'
+
+      resources-dropdown-button-label: 'Recursos'
+      download-unisex-restroom-signs-hyperlink-label: 'Baixar Avisos de Banheiro Unissex'
+      public-api-hyperlink-label: API Pública

--- a/config/locales/pt-BR/navigation.pt-BR.yml
+++ b/config/locales/pt-BR/navigation.pt-BR.yml
@@ -1,7 +1,7 @@
 pt-BR:
   layouts:
     navigation:
-      toggle-navigation-button-label: 'Toggle navigation'
+      toggle-navigation-button-label: 'Alternar navegação'
       submit-a-new-restroom-hyperlink-label: 'Cadastrar Banheiro'
       about-hyperlink-label: 'Sobre'
       contact-hyperlink-label: 'Contato'

--- a/config/locales/pt-BR/pt-BR.yml
+++ b/config/locales/pt-BR/pt-BR.yml
@@ -1,0 +1,33 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   'true': 'foo'
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+pt-BR:
+  hello: "Hello world"

--- a/config/locales/pt-BR/restroom.pt-BR.yml
+++ b/config/locales/pt-BR/restroom.pt-BR.yml
@@ -1,0 +1,60 @@
+pt-BR:
+  activerecord:
+    attributes:
+      restroom:
+        # only overridden attributes here, defaults work as expected
+        # (e.g. database field 'city' will be appear as 'City')
+        name: 'Nome do Estabelecimento/Negócio/Local'
+        street: 'Endereço'
+        state: 'Estado'
+        access: 'Acessível?'
+        bath_type: 'Tipo de banheiro'
+
+  search_bar:
+    enter_location: 'Digite um endereço'
+
+  restroom:
+    add_new: 'Cadastre um banheiro no nosso banco de dados'
+    preview: 'Visualizar'
+    required: '* campo obrigatório'
+    guess_location: 'Adivinhar localização atual'
+    directions: 'Instruções'
+    directions_hint: '(por exemplo: terceiro andar nos fundos, perto dos vestiários...)'
+    comments_hint: '(por exemplo: você tem que ser um "consumidor pagante", aja como se estivesse dando uma olhada...)'
+    comments: 'Comentários'
+    accessible: 'Acessível'
+    not_accessible: 'Não acessível'
+    changing_table: 'Com Trocador'
+    no_changing_table: 'Sem Trocador'
+    type:
+      unisex: 'Unissex / Neutro'
+      single_stall: 'Cabine individual por gênero ou lugar seguro'
+    restsubmit: 'Cadastrar Banheiro'
+    rating:
+      positive: '%{percentage}% positivo'
+      unrated: 'Não avaliado'
+    upvote: 'Adorei!'
+    downvote: 'Não seguro'
+    confirm:
+      upvote: 'Tem certeza que deseja avaliar positivamente este banheiro?'
+      downvote: 'Tem certeza que deseja avaliar negativamente este banheiro?'
+    flash:
+      field: 'Um campo obrigatório foi deixado em branco. Por favor revise seu cadastro e envie o formulário novamente.'
+      unexpected: 'Tivemos um problema inesperado, por favor entre em contato se o problema persistir.'
+      upvoteerror: 'Houve um problema inesperado a avaliar positivamene este local.'
+      upvotesuccess: 'Este banheiro foi avaliado positivamente! Obrigado por contribuir com a nossa comunidade.'
+      downvoteerror: 'Houve um problema inesperado a avaliar negativamente este local.'
+      downvotesuccess: 'Este banheiro foi avaliado negativamente! Obrigado por contribuir com a nossa comunidade.'
+      new: 'Um novo banheiro foi cadastrado por %{name}.'
+      updated: 'Este banheiro foi atualizado'
+      deleted: 'Este banheiro foi removido'
+      searcherror: 'Houve um erro ao buscar a sua localização.'
+      spam: 'Seu cadastro foi rejeitado como spam.'
+    contact:
+      contactlisting: "Entre em contato sobre esta listagem!"
+
+  restrooms:
+    nearby:
+      heading: 'Banheiros próximos'
+      body: 'Antes de cadastrar um banheiro, por favor certifique-se de que ele ainda não está cadastrado.'
+      none: 'Nenhum banheiro foi encontrado por perto.'

--- a/config/locales/pt-BR/restrooms.pt-BR.yml
+++ b/config/locales/pt-BR/restrooms.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  restrooms:
+    index:
+      map-view-button-label: 'Ver mapa'
+
+    show:
+      thumbs-up-button-label: 'Gostei'
+      thumbs-down-button-label: 'Não Gostei'

--- a/config/locales/pt-BR/search.pt-BR.yml
+++ b/config/locales/pt-BR/search.pt-BR.yml
@@ -1,0 +1,6 @@
+pt-BR:
+  layouts:
+    search:
+      search: 'Buscar'
+      search-by-current-location: 'Buscar pela localização atual'
+

--- a/config/locales/pt-BR/signs.pt-BR.yml
+++ b/config/locales/pt-BR/signs.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  pages:
+    signs:
+      title: 'Baixar Avisos de Banheiro'
+      intro: 'Se você tiver um banheiro público no seu prédio ou negócio que é neutro de gênero, divulgue. Você (e/ou quem cuida do prédio/gerência) pode adicioná-lo ao banco de dados, e coloque um dos avisos abaixo para que as pessoas saibam que você apoia acesso seguro para todas as pessoas. Ambos os avisos são arquivos PDF imprimíveis.'
+      head-accessible: 'Banheiros Acessíveis'
+      head-non-accessible: 'Banheiros Não Acessíveis'
+      download: 'Baixe o PDF'

--- a/config/locales/pt-BR/signs.pt-BR.yml
+++ b/config/locales/pt-BR/signs.pt-BR.yml
@@ -2,7 +2,7 @@ pt-BR:
   pages:
     signs:
       title: 'Baixar Avisos de Banheiro'
-      intro: 'Se você tiver um banheiro público no seu prédio ou negócio que é neutro de gênero, divulgue. Você (e/ou quem cuida do prédio/gerência) pode adicioná-lo ao banco de dados, e coloque um dos avisos abaixo para que as pessoas saibam que você apoia acesso seguro para todas as pessoas. Ambos os avisos são arquivos PDF imprimíveis.'
+      intro: 'Se você tiver um banheiro público no seu prédio ou empresa que é neutro de gênero, divulgue. Você (e/ou quem cuida do prédio/gerência) pode adicioná-lo ao banco de dados e ainda colocar um dos avisos abaixo para que se saiba que você apoia o acesso seguro para todas as pessoas. Ambos os avisos são arquivos PDF imprimíveis.'
       head-accessible: 'Banheiros Acessíveis'
       head-non-accessible: 'Banheiros Não Acessíveis'
       download: 'Baixe o PDF'

--- a/config/locales/pt-BR/simple_form.pt-BR.yml
+++ b/config/locales/pt-BR/simple_form.pt-BR.yml
@@ -1,0 +1,55 @@
+# See this documentation: https://github.com/plataformatec/simple_form#i18n
+# And this StackOverflow answer: https://stackoverflow.com/questions/35906089/changing-simple-form-submit-button-i18n-text
+
+pt-BR:
+  simple_form:
+    "yes": 'Sim'
+    "no": 'Não'
+    required:
+      text: 'obrigatório'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Por favor verifique os problemas abaixo:"
+
+    labels:
+      defaults:
+        name: 'Nome'
+        street: 'Endereço'
+        city: 'Cidade'
+        state: 'Estado'
+        country: 'País'
+        accessible: 'Acessível'
+        unisex: 'Unissex'
+        changing_table: 'Trocador'
+        directions: 'Instruções'
+        comment: 'Comentário'
+        email: 'Email'
+        message: 'Mensagem'
+      contact:
+        name: 'Nome'
+        email: 'Email'
+        message: 'Mensagem'
+
+  helpers:
+    submit:
+      contact:
+        # This is the "Send message" button on the "Contact" page.
+        create: 'Enviar mensagem'
+
+    # Labels and hints examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+

--- a/config/locales/pt-BR/splash.pt-BR.yml
+++ b/config/locales/pt-BR/splash.pt-BR.yml
@@ -1,0 +1,6 @@
+pt-BR:
+  pages:
+    index:
+      life-is-tough: 'Às vezes a vida é dura...'
+      find-refuge: 'Encontre Refúgio'
+      add-restroom-button-label: 'Cadastre um banheiro'

--- a/config/locales/pt-BR/text_msg.pt-BR.yml
+++ b/config/locales/pt-BR/text_msg.pt-BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  pages:
+    text:
+      title: 'Ache o banheiro mais próximo por SMS'
+      intro: 'Se você precisa do banheiro mais próximo <em>agora</em>, você pode conseguir por SMS em qualquer telefone que suporte esse serviço.'
+      instructions: 'Mande sua localização para +1 (415) 367-3288 (EUA)'
+      tip: "Pra resultados mais precisos, inclua o endereço, cidade, estado e país. Você receberá o nome e endereço do local imediatamente!"


### PR DESCRIPTION
# Context
- Adds Brazilian Portuguese translation

# Summary of Changes

- creates pt-BR folder in `config/locales`
- adds `:"pt-BR"` to available translations list
- fixes a key typo in `app/views/restrooms/show.html.haml` - 'restrooom' to 'restroom'
- translates all the texts

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
![Refuge Restrooms homepage in English](https://user-images.githubusercontent.com/20157115/47689712-6b4a4280-dbc1-11e8-9d33-54eba8aa04a6.png)

## After
![Refuge Restrooms homepage in Brazilian Portuguese](https://user-images.githubusercontent.com/20157115/47689717-756c4100-dbc1-11e8-9508-7a66ad2f813f.png)
