### PR TITLE
add google maps api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ rerun.txt
 pickle-email-*.html
 config/initializers/secret_token.rb
 config/secrets.yml
-geocoder.rb
 config/initializers/new_framework_defaults_5_1.rb
 config/initializers/application_controller_renderer.rb
 config/cable.yml

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,12 @@
+Geocoder.configure(
+
+  # street address geocoding service (default :nominatim)
+  lookup: :google,
+
+  # to use an API key:
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],
+
+  # geocoding service request timeout, in seconds (default 3):
+  timeout: 5,
+)
+


### PR DESCRIPTION
# Context
- Fixes https://github.com/RefugeRestrooms/refugerestrooms/issues/511 hopefully
- Adds an API key for Google Maps on the server side

# Summary of Changes

- Google Maps API changed to requiring a key in July, I've set up an account with the Refuge google account and added a key
- The key is in Heroku as an env variable
# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
