### PR TITLE
use model where clause instead of loading IDs into memory

### DIFF
--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -40,7 +40,7 @@ class Restroom < ApplicationRecord
   after_find :strip_slashes
 
   scope :current, -> {
-    Restroom.where('id IN (SELECT MAX(id) from restrooms where approved = true group by edit_id)')
+    Restroom.where('id IN (SELECT MAX(id) FROM restrooms WHERE approved = true GROUP BY edit_id)')
   }
 
   scope :accessible, -> { where(accessible: true) }

--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -40,10 +40,7 @@ class Restroom < ApplicationRecord
   after_find :strip_slashes
 
   scope :current, -> {
-    restroom_ids = find_by_sql(
-      "SELECT MAX(id) as id FROM restrooms WHERE approved = true GROUP BY edit_id"
-    )
-    Restroom.where(id: restroom_ids)
+    Restroom.where('id IN (SELECT MAX(id) from restrooms where approved = true group by edit_id)')
   }
 
   scope :accessible, -> { where(accessible: true) }


### PR DESCRIPTION
# Context
- Fixes (hopefully) a bug where restrooms are being loaded into memory before joining with themselves

# Summary of Changes

- Rather than assigning the `GROUP BY` query to a variable, do a nested `SELECT` in a `WHERE` clause when returning current restrooms
