### PR TITLE
Add test for restroom reverse-geocoding.

### DIFF
--- a/app/models/restroom.rb
+++ b/app/models/restroom.rb
@@ -22,6 +22,8 @@ class Restroom < ApplicationRecord
     validates :street, uniqueness: {scope: [:city, :state], message: "is already registered"}
   end
 
+  attribute :force_geocoding
+
   geocoded_by :full_address
   before_validation :perform_geocoding, if: ->(obj){ require_geocoding? }
   before_validation :reverse_geocode, if: ->(obj){ require_geocoding? }
@@ -50,7 +52,7 @@ class Restroom < ApplicationRecord
   scope :updated_since, ->(date) { where("updated_at >= ?", date) }
 
   def require_geocoding?
-    return false if Rails.env == "test"
+    return false if Rails.env == "test" unless force_geocoding
     full_address.present?
   end
 

--- a/spec/factories/restrooms.rb
+++ b/spec/factories/restrooms.rb
@@ -40,5 +40,13 @@ FactoryBot.define do
       state 'CA'
       country 'US'
     end
+
+    factory :weird_restroom do
+      name 'Weirdly formatted restroom'
+      street '123 Example Street'.upcase!
+      city 'San Francisco'.upcase!
+      state 'CA'
+      country 'US'
+    end
   end
 end

--- a/spec/models/restroom_spec.rb
+++ b/spec/models/restroom_spec.rb
@@ -45,4 +45,12 @@ describe Restroom do
     it { expect(Restroom.new.changing_table?).to be false }
     it { expect(Restroom.new(changing_table: true).changing_table?).to be true }
   end
+
+  describe "reverse geocoding" do
+    it "should normalize weird addresses" do
+      weird_restroom = build(:weird_restroom, force_geocoding: true)
+      weird_restroom.save
+      expect(weird_restroom.full_address).to eq "123 Example St.,San Francisco,California,US"
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,3 +59,33 @@ Geocoder::Lookup::Test.add_stub(
     }
   ]
 )
+
+Geocoder::Lookup::Test.add_stub(
+  "123 EXAMPLE STREET,SAN FRANCISCO,CA,US", [
+    {
+      "latitude"     => 37.7749295,
+      "longitude"    => -122.41941550000001,
+      "address"      => "123 Example St., San Francisco, CA, USA",
+      "city"         => "San Francisco",
+      "state"        => "California",
+      "state_code"   => "CA",
+      "country"      => "United States",
+      "country_code" => "US"
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  [37.7749295, -122.41941550000001], [
+    {
+      "latitude"     => 37.7749295,
+      "longitude"    => -122.41941550000001,
+      "address"      => "123 Example St., San Francisco, CA, USA",
+      "city"         => "San Francisco",
+      "state"        => "California",
+      "state_code"   => "CA",
+      "country"      => "United States",
+      "country_code" => "US"
+    }
+  ]
+)


### PR DESCRIPTION
See PR #529 

  - Added force_geocoding attribute for geocoding a model even when the test environment is active. 
  - Added weird_restroom factory.
  - Added geocoding stubs for weird_restroom.
  - Added test for reverse geocoding.
