### PR TITLE
Add alt attributes to badges on the splash page for accessibility

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -18,11 +18,11 @@
         %i.fa.fa-plus-square-o.fa-2x
   .row.even-more-headroom
     .col-xs-6.col-sm-3.col-sm-offset-3
-      = link_to image_tag("app-store.svg", role: "img", alt: "Download on the App Store"), "https://itunes.apple.com/us/app/refuge-restrooms/id968531953?mt=8"
+      = link_to image_tag("app-store.svg", role: "img", alt: t('.html-alt-attributes.app-store')), "https://itunes.apple.com/us/app/refuge-restrooms/id968531953?mt=8"
     .col-xs-6.col-sm-3
-      = link_to image_tag("play-store.png", alt: "Get it on Google Play"), "https://play.google.com/store/apps/details?id=org.refugerestrooms"
+      = link_to image_tag("play-store.png", alt: t('.html-alt-attributes.play-store')), "https://play.google.com/store/apps/details?id=org.refugerestrooms"
 
   .row.more-headroom.splash-bottom-padding
     .col-xs-12.col-sm-6.col-sm-offset-3
-      = link_to image_tag("patreon.png", alt: "Become a patron"), "https://patreon.com/refugerestrooms"
+      = link_to image_tag("patreon.png", alt: t('.html-alt-attributes.patreon')), "https://patreon.com/refugerestrooms"
   = render 'layouts/footer'

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -18,11 +18,11 @@
         %i.fa.fa-plus-square-o.fa-2x
   .row.even-more-headroom
     .col-xs-6.col-sm-3.col-sm-offset-3
-      = link_to image_tag("app-store.svg", role: "img"), "https://itunes.apple.com/us/app/refuge-restrooms/id968531953?mt=8"
+      = link_to image_tag("app-store.svg", role: "img", alt: "Download on the App Store"), "https://itunes.apple.com/us/app/refuge-restrooms/id968531953?mt=8"
     .col-xs-6.col-sm-3
-      = link_to image_tag("play-store.png"), "https://play.google.com/store/apps/details?id=org.refugerestrooms"
+      = link_to image_tag("play-store.png", alt: "Get it on Google Play"), "https://play.google.com/store/apps/details?id=org.refugerestrooms"
 
   .row.more-headroom.splash-bottom-padding
     .col-xs-12.col-sm-6.col-sm-offset-3
-      = link_to image_tag("patreon.png"), "https://patreon.com/refugerestrooms"
+      = link_to image_tag("patreon.png", alt: "Become a patron"), "https://patreon.com/refugerestrooms"
   = render 'layouts/footer'

--- a/config/locales/en/splash.en.yml
+++ b/config/locales/en/splash.en.yml
@@ -6,6 +6,6 @@ en:
       add-restroom-button-label: 'Add A Restroom'
 
       html-alt-attributes:
-        app-store: 'Download on the App Store'
-        play-store: 'Get it on Google Play'
-        patreon: 'Become a patron'
+        app-store: 'Refuge Restrooms iOS app download'
+        play-store: 'Refuge Restrooms Android app download'
+        patreon: 'Support the project on Patreon'

--- a/config/locales/en/splash.en.yml
+++ b/config/locales/en/splash.en.yml
@@ -4,3 +4,8 @@ en:
       life-is-tough: 'Sometimes life is tough...'
       find-refuge: 'Find Refuge'
       add-restroom-button-label: 'Add A Restroom'
+
+      html-alt-attributes:
+        app-store: 'Download on the App Store'
+        play-store: 'Get it on Google Play'
+        patreon: 'Become a patron'


### PR DESCRIPTION
# Context
- Adds alt text to badges on the homepage, for accessibility purposes.

# Summary of Changes

- Add alt text for these badges:
  - App Store link
  - Google Play link
  - Patreon link

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![WAVE accessibility evaluation tool shows three errors relating to missing alt text on images within links.](https://user-images.githubusercontent.com/20157115/53128103-0d57b700-3532-11e9-8fa8-cd4c8085e901.png)

## After

![WAVE accessibility evaluation tool now shows no errors. Three "features" are identified, namely images within links that have alt text.](https://user-images.githubusercontent.com/20157115/53127869-72f77380-3531-11e9-962b-aae112adf5d3.png)