### PR TITLE
db/seeds.rb: Give restroom entries an edit_id

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,8 @@
 require 'csv'
 
 Restroom.transaction do
-  CSV.foreach('db/export.csv').with_index(1) do |row, i|
-    Restroom.create(
+  CSV.foreach('db/export.csv') do |row|
+    restroom = Restroom.create(
       :name => row[1],
       :street => row[3],
       :city => row[4],
@@ -21,8 +21,8 @@ Restroom.transaction do
       :comment => row[12],
       :latitude => row[8],
       :longitude => row[9],
-      :country => row[6],
-      :edit_id => i
+      :country => row[6]
       )
+    restroom.update(edit_id: restroom.id)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 require 'csv'
 
 Restroom.transaction do
-  CSV.foreach('db/export.csv') do |row|
+  CSV.foreach('db/export.csv').with_index(1) do |row, i|
     Restroom.create(
       :name => row[1],
       :street => row[3],
@@ -21,7 +21,8 @@ Restroom.transaction do
       :comment => row[12],
       :latitude => row[8],
       :longitude => row[9],
-      :country => row[6]
+      :country => row[6],
+      :edit_id => i
       )
   end
 end


### PR DESCRIPTION
# Context
- Fixes #541
- This issue was that all the data in development environment were grouped together (as if they were serial edits of the same original restroom), and so only one restroom entry was being displayed.

# Summary of Changes

In `db/seeds.rb`:
- For each entry being generated from the .CSV file, copy the generated `id` value to also be the `edit-id` value. 
  - This ends up giving a matching `id` and `edit_id` to every entry.

[Edited the above: This no-longer count up the `edit_id` number from 1 by iterating the loop; It now reads the `id` value of the restroom entry, and copies that as the (matching) `edit_id` value.]

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![Refuge Restrooms API documentation page, showing only one restroom entry with edit_id: 0](https://user-images.githubusercontent.com/20157115/55198632-2ab11e00-518d-11e9-8c63-bbc2c1604891.png)

## After

![API documentation page, showing multiple restroom entries, where each entry has matching edit_id and id values](https://user-images.githubusercontent.com/20157115/55198630-27b62d80-518d-11e9-92e6-87b61911072c.png)