### PR TITLE
Make filter with "focus" class more readable

### DIFF
--- a/app/assets/stylesheets/restrooms/main.scss
+++ b/app/assets/stylesheets/restrooms/main.scss
@@ -125,6 +125,10 @@
         overflow: hidden;
         margin: 8px;
     }
+
+    &.focus {
+      color: white;
+    }
 }
 .filter i.fa{
     font-size: 22px;


### PR DESCRIPTION
# Context
- Fixes #582

# Summary of Changes

Update filter with class `focus` to use a more readable color

# Screenshots

## Before
<img width="438" alt="Screen Shot 2019-04-24 at 8 04 36 PM" src="https://user-images.githubusercontent.com/5015020/56773170-e4da7c00-6771-11e9-8386-56b8da8f6a34.png">

## After
<img width="354" alt="Screen Shot 2019-04-25 at 3 50 20 PM" src="https://user-images.githubusercontent.com/5015020/56773174-e6a43f80-6771-11e9-9b6e-76e95e11a417.png">
