### PR TITLE
Word wrap dropdown menu

### DIFF
--- a/app/assets/stylesheets/components/nav.scss
+++ b/app/assets/stylesheets/components/nav.scss
@@ -42,4 +42,14 @@
       cursor: pointer;
       top: 2px
   }
+
+  .dropdown-menu > li  {
+    &:not(:last-child) {
+      border-bottom: 1px solid $light-gray;
+    }
+
+    > a {
+      white-space: normal;
+    }
+  }
 }

--- a/app/assets/stylesheets/sass/_variables.scss
+++ b/app/assets/stylesheets/sass/_variables.scss
@@ -11,5 +11,6 @@ $green: #69b94a;
 $yellow: #f5a939;
 $red: #d6564b;
 $gray: #AAA;
+$light-gray: #eee;
 $white: #FFFFFF;
 $rounded-corners: 5px;

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -20,7 +20,6 @@
                 = t('.resources-dropdown-button-label')
                 %b.caret
               %ul.dropdown-menu
-                %li
                 %li= link_to t('.download-unisex-restroom-signs-hyperlink-label'), page_path('signs')
                 %li= link_to t('.public-api-hyperlink-label'), '/api/docs/'
         / /.navbar-collapse


### PR DESCRIPTION
# Context
- Fixes #540 

# Summary of Changes
- Wrap text in dropdown menu so that the text fits within the dropdown area. 
- Add light border to bottom of menu items to give each item some more separation

# Screenshots

## Before
<img src="https://user-images.githubusercontent.com/29487319/49464532-f4036200-f7af-11e8-8900-f05d5fbe5bb7.png">

## After
<img width="633" alt="Screen Shot 2019-04-25 at 4 18 53 PM" src="https://user-images.githubusercontent.com/5015020/56774124-181f0a00-6776-11e9-9d8a-b53c5efeb2fc.png">
