### PR TITLE
Add "locale=" URL parameter to the webapp (prepares for adding a locale switcher)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   end
 
    def set_locale
-     I18n.locale = http_accept_language.language_region_compatible_from(I18n.available_locales)
+     I18n.locale = params[:locale] || http_accept_language.language_region_compatible_from(I18n.available_locales)
    end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
      I18n.locale = params[:locale] || http_accept_language.language_region_compatible_from(I18n.available_locales)
    end
 
+  def default_url_options
+    { locale: I18n.locale }
+  end
+
 end

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -4,7 +4,7 @@
       %nav.nav.navbar-default{:role => "navigation"}
         / Brand and toggle get grouped for better mobile display
         .navbar-header
-          %a#logo.toiletLogo{:href => "/"}
+          = link_to root_path, id: "logo", class: "toiletLogo" do
             .navbar-brand Refuge Restrooms
           %button.navbar-toggle{"data-target" => "#bs-example-navbar-collapse-1", "data-toggle" => "collapse", :type => "button"}
             %span.sr-only= t('.toggle-navigation-button-label')


### PR DESCRIPTION
# Context
- Partly addresses #428
- Adds a URL parameter `?locale=[your_locale_here]`
  - Prepares app to use the parameter, try to fix hard-coded links that don't have the parameter.

# Summary of Changes

- Add a `?locale=[locale]` default URL parameter to all dynamically-generated links, e.g. links made with the Rails `link_helper` 
- Adjust locale selection to, during page load, look for this `?locale=` parameter, and if present, use that parameter's string as the locale. 
  - (Thus far, locale has only been set from the user's browser locale preference list. There has been no way to specify what language Refuge appears in beside editing the browser locale preferences.)
    - Code in this PR still falls back to the browser locale list if no `?locale=` parameter is present in the URL.
- Initial attempt to track down hard-coded links or redirects, and replace with dynamically generated ones such as with Rails `link_helper` code.
  - So far only adjusted the main homepage link in the far corner of the topnav area.
  - The search box still redirects in a way that does not include the `?locale=` parameter at this time.
    - This should be fixed, or else the search box will break the `?locale=` chain, and make a language switcher seem "broken" and be much less useful.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
