### PR TITLE
Dockerfile: Get latest Node.js within a major version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,20 @@ RUN curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linu
   # Clean up extra (un-needed) PhantomJS files
   && rm -rf phantomjs-2.1.1-linux-x86_64/
 
-# Specify a version of Node.js to download and install
-ENV NODEJS_VERSION=v10.15.3
+# Specify a major version of Node.js to download and install
+ENV NODEJS_MAJOR_VERSION=10
 
 # Download and extract Node.js from archive supplied by nodejs.org
-RUN curl -L https://nodejs.org/dist/$NODEJS_VERSION/node-$NODEJS_VERSION-linux-x64.tar.xz -o nodejs.tar.xz \
+RUN curl -L https://nodejs.org/dist/latest-v$NODEJS_MAJOR_VERSION\.x/SHASUMS256.txt -O \
+  && ARCHIVE_FILENAME=$(grep -o "node-*.*.*-linux-x64.tar.xz" SHASUMS256.txt) \
+  && curl -L https://nodejs.org/dist/latest-v$NODEJS_MAJOR_VERSION.x/$ARCHIVE_FILENAME -o nodejs.tar.xz \
   && tar xf nodejs.tar.xz \
-  # Clean up the Node.js archive
-  && rm nodejs.tar.xz
+  && mv ./node-v*-linux-x64 /usr/local/nodejs \
+  # Clean up the Node.js archive and SHASUMS256.txt
+  && rm nodejs.tar.xz SHASUMS256.txt
 
 # Add Node.js binaries to PATH (includes Node and NPM, will include Yarn)
-ENV PATH="/node-$NODEJS_VERSION-linux-x64/bin/:${PATH}"
+ENV PATH="/usr/local/nodejs/bin/:${PATH}"
 
 # Install Yarn
 RUN npm install -g yarn


### PR DESCRIPTION
# Context
- The recent pull request #586 changed the way Node.js is installed in the Docker container. In order to do a more lightweight installation, we directly download and extract Node.js as a tar archive. This replaced a complex installer script that did `apt install` steps, among other things, which were both slow to complete, and used much network/storage resources. As a part of the changes in that Pull Request, we specify an exact version of the form `node-v[major.minor.patch][...].tar.xz`
- The present pull request changes it so we specify only a major version number, and automatically fetch the latest minor/patch version of that major version number.

# Summary of Changes

- In the Dockerfile, switch from full explicit version number (e.g. node v10.16.0) to just specifying a major version (e.g. node v10) and get the latest minor/patch of that major version.

# Checklist

- [ ] Tested Mobile Responsiveness
- [N/A] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)