### PR TITLE
Faster Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=c18df080592f9c99ca8080a6d5e052aa5fd3964044a0fe0b71e48f8e18998dc2
-language: ruby
+language: minimal
 services: docker
 install:
   - docker-compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres
+    image: postgres:alpine
   web:
     build: .
     entrypoint: [setup/entry]


### PR DESCRIPTION
# Context
- Implements ideas laid out in this comment:
  - https://github.com/RefugeRestrooms/refugerestrooms/pull/586#issuecomment-493680534
  - Credit goes to @btyy77c for essentially doing the same thing in the [dockerAlpine](https://github.com/btyy77c/refugerestrooms/commits/dockerAlpine) branch on their fork. I am just re-doing the same optimizations in a way appropriate for our develop branch at this time. (And without changing the main image to be Alpine-based, at least for now.)
- Makes builds go faster at Travis-ci.com without negatively impacting development (and without any impact on production whatsoever, since we don't use Docker or Travis CI in production).

# Summary of Changes

- Use the `minimal` language for Travis CI, instead of the `ruby` language.
- Use the smaller `postgresql:alpine` base image for our Docker database container, instead of the generic `postgresql` image, which is based on debian.
# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)