### PR TITLE
Remove tumblr link

### DIFF
--- a/app/assets/stylesheets/components/common.scss
+++ b/app/assets/stylesheets/components/common.scss
@@ -141,9 +141,6 @@ footer {
     &.fa-facebook-square:hover {
         color: #3B5998;
     }
-    &.fa-tumblr-square:hover {
-        color: #36465D;
-    }
     &.fa-envelope:hover {
         color: #BE1E2D;
     }

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -6,8 +6,6 @@
       %i.icon.fa.fa-twitter-square.fa-3x
     %a.iconLink{:href => "https://www.facebook.com/refugerestrooms", :aria => { :label => t('.aria-labels.facebook')}}
       %i.icon.fa.fa-facebook-square.fa-3x
-    %a.iconLink{:href => "http://blog.refugerestrooms.org/", :aria => { :label => t('.aria-labels.tumblr')}}
-      %i.icon.fa.fa-tumblr-square.fa-3x
     %a.iconLink{:href => contact_path, :aria => { :label => t('.aria-labels.email')}}
       %i.icon.fa.fa-envelope.fa-3x
     %br/

--- a/config/locales/en/footer.en.yml
+++ b/config/locales/en/footer.en.yml
@@ -5,7 +5,6 @@ en:
         github: 'Refuge Restrooms on GitHub'
         twitter: 'Refuge Restrooms on twitter'
         facebook: 'Refuge Restrooms on Facebook'
-        tumblr: 'Refuge Restrooms blog on tumblr'
         email: 'Email Refuge Restrooms'
       refuge-restrooms-is-open-source: 'refuge restrooms is open source.'
       code-on-github: 'code on github.'


### PR DESCRIPTION
# Context
- Fixes #429
- tumblr blog is inactive. So we can remove the link.

# Summary of Changes

- Delete the tumblr icon (and the associated link to tumblr) from the footer
- Delete a style rule that gave the tumblr icon in the footer a unique color when focused/upon mouseover

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![Refuge Restrooms footer showing five icons](https://user-images.githubusercontent.com/20157115/63457860-ba4ab800-c41f-11e9-8d3a-589c93f606dc.png)

## After

![Refuge Restrooms footer showing four icons](https://user-images.githubusercontent.com/20157115/63457901-ca629780-c41f-11e9-83f1-14fb858ba7bd.png)