### PR TITLE
Removed tumblr from about page

### DIFF
--- a/config/locales/en/about.en.yml
+++ b/config/locales/en/about.en.yml
@@ -14,7 +14,7 @@ en:
     p5header: 'What can we do to help?'
     p5:
       first: "<strong>First:</strong> Add listings. The database is only as big as you make it. The more listings, the more comprehensive and valuable the resource can be."
-      second: "<strong>Secondly:</strong> Spread the word. Tweet. Facebook. Tumblr. Blog. Whatever it is that you do, do it. Let people know about this resource."
+      second: "<strong>Secondly:</strong> Spread the word. Tweet. Facebook. Blog. Whatever it is that you do, do it. Let people know about this resource."
       third: "<strong>Thirdly:</strong> If you know how to code, visit GitHub and let us know about a bug, suggest an improvement, or even contribute a little bit of code and help out the project. REFUGE is open source and we can't do it without you."
       fourth: "<strong>Fourthly: </strong> Donate. Keep your eyes peeled for an upcoming crowd funding campaign to fund some of the technology we need to use as well as to pay our fabulous designers and engineers a little bit of money for their hard and tireless work. They have been working for free to bring this service to you and we don't want anybody to work for free. Most of the core team are transgender and underemployed at this time."
     p6header: "Why is my business or organization listed?"


### PR DESCRIPTION
I noticed we were removing tumblr, here's one more instance 😃

# Context

Previous tumblr removal pull request:
- https://github.com/RefugeRestrooms/refugerestrooms/pull/592

# Summary of Changes

- I noticed that tumblr was the about page, I removed it

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
