### PR TITLE
Set up internationalization (i18n) fallbacks, including Tagalog --> Filipino 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module SaferstallsRails
 
     # I18n stuff
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-    config.i18n.available_locales = [:en, :es, :fil, :fr, :hi, :it, :pl, :"pt-BR"]
+    config.i18n.available_locales = [:en, :es, :fil, :fr, :hi, :it, :pl, :"pt-BR", :tl]
     config.i18n.default_locale = :en
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module SaferstallsRails
     # I18n stuff
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.available_locales = [:en, :es, :fil, :fr, :hi, :it, :pl, :"pt-BR"]
-    #config.i18n.default_locale = :fr
+    config.i18n.default_locale = :en
 
 
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,7 +70,8 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = I18n.default_locale
+  config.i18n.fallbacks = {:tl => [:fil,I18n.default_locale]}
+  config.i18n.fallbacks.default = I18n.default_locale
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,7 +70,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = I18n.default_locale
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
# Context
- Follow-up to #596, which added the Filipino locale, short code `fil`
- Make sure Tagalog (`tl`) falls back correctly to Filipino (`fil`), and set up the locale fallback logic correctly in general.
- Enable Firefox users to request Tagalog (`tl`) -- As far as I know, only Chromium/Chrome users can request Filipino (`fil`). And likewise, Chromium/Chrome users cannot request Tagalog (`tl`).
- Should have no impact to end-users, other than enabling Tagalog (`tl`) to return the translations in our `config/locales/fil` folder. Thank you to various contributors for that translation, most recently @brynmrk.

# Summary of Changes

- Set `I18n.default_locale` explicitly to English (`en`) (was only _implicitly_ English before, as part of the default behavior of Rails)
- Add Tagalog (`tl`) to the list of supported locales for our app.
- Instruct the app that when a user requests Tagalog (`tl`), it should fall back to our Filipino (`fil`) translations... (and if there are gaps in the Filipino (`fil`) translation, fall back only for those specific missing strings to the default locale, which is now English (`en`).
  - In all other cases, only the default locale, English (`en`), is currently set up for fallback. This should only occur if there are gaps in translations. For example, this would occur if we add new strings to the English locale without adding the new strings to each other locale.
    - Again, to clarify: Fallback to English would only occur for the specific strings we haven't gotten translations for yet.
- Technical version of the above bullet point: Update production's value of `config.i18n.fallbacks` from `true` (which is [deprecated](https://github.com/ruby-i18n/i18n/releases/tag/v1.1.0)) to a more complex arrangement.
  - Tagalog (`tl`) falls back to Filipino (`fil`) first, then the default locale (English (`en`))
  - Everything else falls back only to the default locale (English (`en`))
  - Note: Fallbacks are only needed when the requested locale is missing the requested string. For lookup of each individual string, Rails will preferentially use the first locale in the list.
    - The list looks like this: [requested locale], [if requested locale was, `tl`, then `fil` goes here], `en`

# Checklist

- [x] Tested changes work properly
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
