### PR TITLE
.travis.yml: Set "dist" to "trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=c18df080592f9c99ca8080a6d5e052aa5fd3964044a0fe0b71e48f8e18998dc2
 language: minimal
+dist: trusty
 services: docker
 install:
   - docker-compose build


### PR DESCRIPTION
# Context
- Our Travis CI tests have been failing lately, ever since Travis CI automatically switched our base image for testing to Ubuntu 16.04 "Xenial".
- Edit: See #601 for an issue that gives more details.
  - This pull request is not an actual fix for that issue, it's just a workaround. Notably, tests do not seem to pass locally or in a local Docker instance, leaving an outdated CI environment as the only place to run our tests. Fixing that issue would be good for a number of reasons, in my personal view.
- This switches us back to using the Ubuntu 14.04 "Trusty" base image. This should allow our CI tests to pass while we investigate test failures on Travis CI's xenial base image.


# Summary of Changes

- Set the `dist` key to `trusty` in `.travis.yml`

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)