### PR TITLE
Dockerfile: Upgrade Node from v10.x to v12.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linu
 ENV OPENSSL_CONF=/etc/ssl/
 
 # Specify a major version of Node.js to download and install
-ENV NODEJS_MAJOR_VERSION=10
+ENV NODEJS_MAJOR_VERSION=12
 
 # Download and extract Node.js from archive supplied by nodejs.org
 RUN curl -L https://nodejs.org/dist/latest-v$NODEJS_MAJOR_VERSION\.x/SHASUMS256.txt -O \


### PR DESCRIPTION
# Context
- NodeJS promoted the 12.x branch to being a Long Term Service (LTS) release on October 21st, per their [release schedule](https://nodejs.org/en/about/releases/).
- Heroku automatically installs the latest (highest-numbered) LTS release unless we specify otherwise in our [package.json](https://github.com/RefugeRestrooms/refugerestrooms/blob/develop/package.json) (similar to how we have [specified a version of Yarn](https://github.com/RefugeRestrooms/refugerestrooms/blob/17f87626e5f6ddc919c8699d2b09cc95b0a99f50/package.json#L16-L17).)
  - We should probably develop against the same version of Node as will be used in production. So we can pin a version in `package.json`, or just keep track and update the `Dockerfile` as needed.

# Summary of Changes

- Switch from Node 10.x to 12.x in Dockerfile

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)