### PR TITLE
Tweak CSS a bit for narrow screens (e.g. mobile phones)

### DIFF
--- a/app/assets/stylesheets/_mobile.scss
+++ b/app/assets/stylesheets/_mobile.scss
@@ -8,6 +8,18 @@
 
 // Screen Width-Related Rules
 
+@media only screen and (max-width: 342px), only screen and (max-device-width: 344px) {
+
+    button.splash-add-restroom-btn > i.fa-plus-square-o {
+        margin-left: 2%;
+    }
+
+    .splash-background > .container > .row.min-headroom > .col-xs-12 {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
 @media only screen and (max-width: 640px), only screen and (max-device-width: 640px) {
     main, main .container {
         padding-left: 0;

--- a/app/assets/stylesheets/_mobile.scss
+++ b/app/assets/stylesheets/_mobile.scss
@@ -14,7 +14,7 @@
         margin-left: 2%;
     }
 
-    .splash-background > .container > .row.min-headroom > .col-xs-12 {
+    .nav-column {
         padding-left: 0;
         padding-right: 0;
     }

--- a/app/assets/stylesheets/framework_and_overrides.scss
+++ b/app/assets/stylesheets/framework_and_overrides.scss
@@ -40,3 +40,9 @@ header {
   margin-left: auto;
   margin-right: auto;
 }
+
+// Eliminates double-padding due to nested .container divs
+.header > .container > .container {
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -1,6 +1,6 @@
 .container
   .row.min-headroom
-    .col-xs-12
+    .col-xs-12.nav-column
       %nav.nav.navbar-default{:role => "navigation"}
         / Brand and toggle get grouped for better mobile display
         .navbar-header


### PR DESCRIPTION
# Context
- Tweak a couple of styles that didn't work so well on screens under ~340px

# Summary of Changes

- Eliminated left and right padding for a div containing the nav section, only on narrow screens
- Reduced left margin for the "[+]" in the "Add a Restroom [+]" button on the splash page, only for narrow screens
- Fit for most smartphones, but not exactly great on certain smartwatches (say, under 200px wide)

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

Taken on an iPhone "5" series of phone.

## Before

![splash-1-before](https://user-images.githubusercontent.com/20157115/71426999-b6a29880-2680-11ea-9194-2a43855a7975.jpeg)
![splash-2-before](https://user-images.githubusercontent.com/20157115/71427000-b6a29880-2680-11ea-9495-882b5e7ba18a.png)
![contact-before](https://user-images.githubusercontent.com/20157115/71426998-b6a29880-2680-11ea-81b8-49a7d9635ea5.png)

## After


![splash-1-after](https://user-images.githubusercontent.com/20157115/71427008-d33ed080-2680-11ea-94d1-5cfc3266324b.png)
![splash-2-after](https://user-images.githubusercontent.com/20157115/71427009-d33ed080-2680-11ea-93e5-1605f6ff8783.png)
![contact-after](https://user-images.githubusercontent.com/20157115/71427005-cd48ef80-2680-11ea-8651-f5dd4df8a87d.png)