### PR TITLE
CSS: Center logo and brand name on narrow screens

### DIFF
--- a/app/assets/stylesheets/_mobile.scss
+++ b/app/assets/stylesheets/_mobile.scss
@@ -8,18 +8,6 @@
 
 // Screen Width-Related Rules
 
-@media only screen and (max-width: 342px), only screen and (max-device-width: 344px) {
-
-    button.splash-add-restroom-btn > i.fa-plus-square-o {
-        margin-left: 2%;
-    }
-
-    .nav-column {
-        padding-left: 0;
-        padding-right: 0;
-    }
-}
-
 @media only screen and (max-width: 767px), only screen and (max-device-width: 767px) {
     .navbar-default .toiletLogo {
         top: 8px;
@@ -60,9 +48,9 @@
     }
     .showPageContent {
         padding: 10px;
-
     }
 }
+
 @media only screen and (max-width: 480px), only screen and (max-device-width: 480px) {
     .container {
         width: 100%;
@@ -96,6 +84,17 @@
         font-size: 15px;
     }
 }
+
+@media only screen and (max-width: 342px), only screen and (max-device-width: 344px) {
+    button.splash-add-restroom-btn > i.fa-plus-square-o {
+        margin-left: 2%;
+    }
+    .nav-column {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
 a.iconLink:hover {
     text-decoration: none;
 }

--- a/app/assets/stylesheets/_mobile.scss
+++ b/app/assets/stylesheets/_mobile.scss
@@ -20,6 +20,12 @@
     }
 }
 
+@media only screen and (max-width: 767px), only screen and (max-device-width: 767px) {
+    .navbar-default .toiletLogo {
+        top: 8px;
+    }
+}
+
 @media only screen and (max-width: 640px), only screen and (max-device-width: 640px) {
     main, main .container {
         padding-left: 0;


### PR DESCRIPTION
# Context
- The logo and "brand name" text ("Refuge Restrooms") in the navbar look a bit off on narrow screens, such as most smartphones, at the moment.
  - The text and logo are too vertically high, and they are therefore not centered.

# Summary of Changes

- Lower the navbar's logo anchor element by 10px on affected narrow screens (767px wide or narrower).
  - The "brand name" text is in a `<div>` inside this `<a>` element, so it is lowered by this change as well. 
- Re-ordered some rules in `_mobile.scss` to a more logical/readable order (my fault that the order became odd in the first place), and made newline spacing more consistent, while I was there.

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots
## Before
![Refuge Restrooms navbar with logo and brand name vertically high of center](https://user-images.githubusercontent.com/20157115/73202324-c5a9ba00-4108-11ea-9f5b-bea5a1cc7391.png)

## After
![Refuge Restrooms navbar with logo and brand name vertically centered](https://user-images.githubusercontent.com/20157115/73286204-2dbdd600-41c5-11ea-972e-9c5b7f41dc46.png)