### PR TITLE
Add a locale switcher

### DIFF
--- a/app/assets/stylesheets/components/common.scss
+++ b/app/assets/stylesheets/components/common.scss
@@ -145,3 +145,7 @@ footer {
         color: #BE1E2D;
     }
 }
+
+.locale_link {
+    margin: 0px 5px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   end
 
    def set_locale
-     I18n.locale = http_accept_language.language_region_compatible_from(I18n.available_locales)
+     I18n.locale = params[:locale] || http_accept_language.language_region_compatible_from(I18n.available_locales)
    end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
      I18n.locale = params[:locale] || http_accept_language.language_region_compatible_from(I18n.available_locales)
    end
 
+  def default_url_options
+    { locale: I18n.locale }
+  end
+
 end

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -18,11 +18,18 @@
     = "\&copy; #{t('.copyleft')}  #{Date.today.year} #{t('.refuge-restrooms')}".html_safe
     %br/
     %br/
-    = link_to 'English', request.query_parameters.merge({:locale => 'en'})
-    = link_to 'Español', request.query_parameters.merge({:locale => 'es'})
-    = link_to 'Filipino/Tagalog', request.query_parameters.merge({:locale => 'fil'})
-    = link_to 'Français', request.query_parameters.merge({:locale => 'fr'})
-    = link_to 'हिन्दी', request.query_parameters.merge({:locale => 'hi'})
-    = link_to 'Italiano', request.query_parameters.merge({:locale => 'it'})
-    = link_to 'polski', request.query_parameters.merge({:locale => 'pl'})
-    = link_to 'Português do Brasil', request.query_parameters.merge({:locale => 'pt-BR'})
+    = link_to 'English', request.query_parameters.merge({:locale => 'en'}), class: "locale_link"
+    &bull;
+    = link_to 'Español', request.query_parameters.merge({:locale => 'es'}), class: "locale_link"
+    &bull;
+    = link_to 'Filipino/Tagalog', request.query_parameters.merge({:locale => 'fil'}), class: "locale_link"
+    &bull;
+    = link_to 'Français', request.query_parameters.merge({:locale => 'fr'}), class: "locale_link"
+    &bull;
+    = link_to 'हिन्दी', request.query_parameters.merge({:locale => 'hi'}), class: "locale_link"
+    &bull;
+    = link_to 'Italiano', request.query_parameters.merge({:locale => 'it'}), class: "locale_link"
+    &bull;
+    = link_to 'polski', request.query_parameters.merge({:locale => 'pl'}), class: "locale_link"
+    &bull;
+    = link_to 'Português do Brasil', request.query_parameters.merge({:locale => 'pt-BR'}), class: "locale_link"

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -16,4 +16,13 @@
     %a{:href => "https://patreon.com/refugerestrooms"} #{t('.on-patreon')}
     %br/
     = "\&copy; #{t('.copyleft')}  #{Date.today.year} #{t('.refuge-restrooms')}".html_safe
-
+    %br/
+    %br/
+    = link_to 'English', request.query_parameters.merge({:locale => 'en'})
+    = link_to 'Español', request.query_parameters.merge({:locale => 'es'})
+    = link_to 'Filipino/Tagalog', request.query_parameters.merge({:locale => 'fil'})
+    = link_to 'Français', request.query_parameters.merge({:locale => 'fr'})
+    = link_to 'हिन्दी', request.query_parameters.merge({:locale => 'hi'})
+    = link_to 'Italiano', request.query_parameters.merge({:locale => 'it'})
+    = link_to 'polski', request.query_parameters.merge({:locale => 'pl'})
+    = link_to 'Português do Brasil', request.query_parameters.merge({:locale => 'pt-BR'})

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -21,5 +21,5 @@
                 %b.caret
               %ul.dropdown-menu
                 %li= link_to t('.download-unisex-restroom-signs-hyperlink-label'), page_path('signs')
-                %li= link_to t('.public-api-hyperlink-label'), '/api/docs/'
+                %li= link_to t('.public-api-hyperlink-label'), api_docs_path
         / /.navbar-collapse

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -4,7 +4,7 @@
       %nav.nav.navbar-default{:role => "navigation"}
         / Brand and toggle get grouped for better mobile display
         .navbar-header
-          %a#logo.toiletLogo{:href => "/"}
+          = link_to root_path, id: "logo", class: "toiletLogo" do
             .navbar-brand Refuge Restrooms
           %button.navbar-toggle{"data-target" => "#bs-example-navbar-collapse-1", "data-toggle" => "collapse", :type => "button"}
             %span.sr-only= t('.toggle-navigation-button-label')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,18 +2,27 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   devise_for :admin_users, ActiveAdmin::Devise.config
+    get '/:locale' => 'pages#index'
+    root 'pages#index'
+
     ActiveAdmin.routes(self)
-    resources :restrooms, except: [:edit, :destroy]
+    scope "(:locale)" do
+      resources :restrooms, except: [:edit, :destroy]
+    end
 
     namespace :api do
-      resources :docs, only: [:index]
+      scope "(:locale)" do
+        resources :docs, only: [:index]
+      end
     end
 
     mount API::Base => '/api'
+    scope "(:locale)" do
+      get '/contact', to: 'contacts#new'
+      get "/*id" => 'pages#show', as: :page, format: false
+    end
 
-    get '/contact', to: 'contacts#new'
-    get "/*id" => 'pages#show', as: :page, format: false
-    root 'pages#index'
-
-    resources "contacts", only: [:new, :create]
+    scope "(:locale)" do
+      resources "contacts", only: [:new, :create]
+    end
 end

--- a/spec/features/contacts_spec.rb
+++ b/spec/features/contacts_spec.rb
@@ -4,7 +4,7 @@ describe 'the contact process', type: :feature do
   it 'should show a generic contact when contact is not from restroom form' do
     restroom = create(:restroom, name: "Mission Creek Cafe")
 
-    visit restroom_path restroom
+    visit restroom_path(:id => restroom.id)
     click_link 'Contact'
 
     expect(page).to_not have_content('Mission Creek Cafe')


### PR DESCRIPTION
# Context
- Finishes the work started in #585
- Fixes #428
- Adds a language switcher, rewires some of the routing and locale handling to support the locale switcher.

# Summary of Changes

- Add a default URL parameter, `:locale` that will render as `?locale=[your-locale-code-here]` in the URL. E.g. `/restrooms/new?locale=es` is the "Add a New Restroom" page, explicitly in Spanish.
- Enable optional routing to locale-prefixed versions of most URLs in the app. E.g. `/fr/restrooms/new` is the "Add a New Restroom" page, explicitly in French.
- Add locale-switching links to the footer, approach inspired by the footer at https://rubygems.org
- Most dynamically-generated links automagically use the locale prefixes (like `/pt-BR/`) now.
  - Exceptions appear to be... `/admin` (locale switcher and URL prefixing don't seem to work here.)
  - The site root/homepage `/` can work with locale prefixes, but the link in the header seems to prefer locale parameters `/?locale=[your-locale-code-here]`

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
