### PR TITLE
Add reference to docker troubleshooting wiki in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ _(Older Mac or Windows PC? See [instructions for Docker Toolbox](https://github.
 
 _(Running Linux? See [instructions for Docker CE on Linux](https://github.com/RefugeRestrooms/refugerestrooms/wiki/How-to-use-Docker-CE-on-Linux-with-Refuge-Restrooms).)_
 
-Trouble with setting up docker? The [Troubleshooting Docker wiki](https://github.com/RefugeRestrooms/refugerestrooms/wiki/Troubleshooting-Docker) outlines solutions for common errors.
+Trouble with docker? The [Troubleshooting Docker wiki](https://github.com/RefugeRestrooms/refugerestrooms/wiki/Troubleshooting-Docker) outlines solutions for common errors.
 
 ### 3 Build the Docker Containers
 Build the containers from any [terminal](https://github.com/RefugeRestrooms/refugerestrooms/wiki/What-is-a-Terminal-(or-%22Terminal-Emulator%22)%3F-How-do-I-run-text-based-commands-on-my-computer%3F) program with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ _(Older Mac or Windows PC? See [instructions for Docker Toolbox](https://github.
 
 _(Running Linux? See [instructions for Docker CE on Linux](https://github.com/RefugeRestrooms/refugerestrooms/wiki/How-to-use-Docker-CE-on-Linux-with-Refuge-Restrooms).)_
 
+Trouble with setting up docker? The [Troubleshooting Docker wiki](https://github.com/RefugeRestrooms/refugerestrooms/wiki/Troubleshooting-Docker) outlines solutions for common errors.
+
 ### 3 Build the Docker Containers
 Build the containers from any [terminal](https://github.com/RefugeRestrooms/refugerestrooms/wiki/What-is-a-Terminal-(or-%22Terminal-Emulator%22)%3F-How-do-I-run-text-based-commands-on-my-computer%3F) program with:
 ```


### PR DESCRIPTION
# Context
- Supports #624
- Add to `CONTRIBUTING.md` to direct people to existing wiki resources in the case that they run into issues during project setup. 

# Summary of Changes

- Added link to docker troubleshooting wiki in `CONTRIBUTING.md`

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [x] Added Documentation (Service and Code when required)

# Screenshots

## Before
<img width="913" alt="Screen Shot 2020-06-23 at 1 10 38 PM" src="https://user-images.githubusercontent.com/65255475/85455776-1d7f0c80-b553-11ea-9d49-5bdceba7ebce.png">

## After
<img width="878" alt="Screen Shot 2020-06-23 at 1 10 22 PM" src="https://user-images.githubusercontent.com/65255475/85455789-21ab2a00-b553-11ea-9d46-4b796beafae7.png">

