### PR TITLE
Add listeners to close infowindow when another is opened

### DIFF
--- a/app/javascript/packs/lib/maps.js.erb
+++ b/app/javascript/packs/lib/maps.js.erb
@@ -8,6 +8,7 @@ const circleMarkerImage = "<%= helpers.image_path('marker-circle.png') %>";
 const showMarkerImage = "<%= helpers.image_path('show-icon.png') %>";
 
 let map;
+let lastOpenedInfoWindow;
 
 function initMap(x, y, image, draggable, callback){
   image = typeof image !== 'undefined' ? image : currentLocationImage;
@@ -81,8 +82,20 @@ function placeMarker(lat, lng, content, number){
   });
 
   marker.addListener('click', function() {
+    closeLastOpenedInfoWindow();
     infoWindow.open(map, marker);
+    lastOpenedInfoWindow = infoWindow;
   });
+
+  google.maps.event.addListener(map, 'click', function(event) {
+    infoWindow.close();
+  });
+}
+
+function closeLastOpenedInfoWindow() {
+    if (lastOpenedInfoWindow) {
+        lastOpenedInfoWindow.close();
+    }
 }
 
 function generateContent(data){


### PR DESCRIPTION
# Context
- Fixes #627 
- Select one bathroom at a time in the Map View
- Close windows when clicking "out" to the map

# Summary of Changes

- Added on-click listener to close an open `infoWindow` when the map is selected
- Added a global variable to capture the most recently opened `infoWindow`
- Added logic to close an opened `infoWindow` when another marker (bathroom) is selected

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

![2020-06-23 13 25 39](https://user-images.githubusercontent.com/65255475/85486851-51245b80-b580-11ea-922e-8edaf6172f28.gif)

## After

![2020-06-23 14 33 18](https://user-images.githubusercontent.com/65255475/85610168-9b065380-b60b-11ea-9391-6647ac0b76b4.gif)