### PR TITLE
README.md: Update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please also read our [Code of Conduct](https://github.com/RefugeRestrooms/refuge
 
 ## Slack
 
-If you want to join the Refuge Restrooms Slack channel, you can do so by [clicking on this link.](https://join.slack.com/t/refugelgbt/shared_invite/enQtMzExOTAyMTExMjM3LTk2ZDQzNGFmMzFlY2YyZGI1NTU1YzFhMGFlZTdlNzA2MDlkYTRjNWVkMTVkOTlhZjJmNGFkMzY3NjFhZjgyMzM)
+If you want to join the Refuge Restrooms Slack channel, you can do so by [clicking on this link.](https://join.slack.com/t/refugelgbt/shared_invite/zt-3zaagpad-DvyfAPcepuRzFBJix1uYkg)
 
 ## License
 


### PR DESCRIPTION
# Context
- Our Slack invite link has been expired for some time now... Needs an update!

# Summary of Changes

- Generated a new Slack invite link, and replaced the old one in `README.md`
  - Slack's web UI says this link will _not_ expire.
  - Come on in! https://join.slack.com/t/refugelgbt/shared_invite/zt-3zaagpad-DvyfAPcepuRzFBJix1uYkg

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [x] Added Documentation (Service and Code when required)