### PR TITLE
Keeping filters state on pagination

### DIFF
--- a/app/javascript/packs/views/restrooms/restrooms.js
+++ b/app/javascript/packs/views/restrooms/restrooms.js
@@ -3,27 +3,62 @@
 // You can use CoffeeScript in this file: http://coffeescript.org/
 
 $(() => {
+  function getSearchParams() {
+    const { search: search } = location;
+    return new URLSearchParams(search);
+  }
+  function applyFilters(filters) {
+    const { origin: url, pathname: path } = location;
+    const searchParams = getSearchParams();
+    searchParams.set('filters', filters);
+    location = `${url}${path}?${searchParams.toString()}`
+  }
+
+  function getFilters() {
+    const searchParams = getSearchParams();
+    const filters = searchParams.get('filters') || '';
+    return filters.split(',').filter(filter => filter && filter.length > 0);
+  }
+
+  function removeFilter(toRemove) {
+    const filters =
+      getFilters()
+      .filter((filter) => filter != toRemove);
+
+    applyFilters(filters);
+  }
+
+  function addFilter(filter) {
+    let filters = getFilters();
+
+    if (filters.indexOf(filter) == -1) {
+      filters.push(filter);
+    }
+
+    applyFilters(filters);
+  }
+
   $('#ada_filter').click(function() {
     if ($(this).hasClass("active")) {
-      $('.listItem.not_accessible').show();
+      removeFilter('accessible');
     } else {
-      $('.listItem.not_accessible').hide();
+      addFilter('accessible');
     }
   });
 
   $('#unisex_filter').click(function() {
     if ($(this).hasClass("active")) {
-      $('.listItem.not_unisex').show();
+      removeFilter('unisex');
     } else {
-      $('.listItem.not_unisex').hide();
+      addFilter('unisex');
     }
   });
 
   $('#changing_table_filter').click(function() {
     if ($(this).hasClass("active")) {
-      $('.listItem.no_changing_table').show();
+      removeFilter('changing_table');
     } else {
-      $('.listItem.no_changing_table').hide();
+      addFilter('changing_table');
     }
   });
 });

--- a/app/javascript/packs/views/restrooms/restrooms.js
+++ b/app/javascript/packs/views/restrooms/restrooms.js
@@ -38,27 +38,21 @@ $(() => {
     applyFilters(filters);
   }
 
-  $('#ada_filter').click(function() {
-    if ($(this).hasClass("active")) {
-      removeFilter('accessible');
-    } else {
-      addFilter('accessible');
-    }
-  });
+  function addOnClickEvent([filterElementId, filter]) {
+    $(filterElementId).click(function() {
+      if ($(this).hasClass("active")) {
+        removeFilter(filter);
+      } else {
+        addFilter(filter);
+      }
+    });
+  }
 
-  $('#unisex_filter').click(function() {
-    if ($(this).hasClass("active")) {
-      removeFilter('unisex');
-    } else {
-      addFilter('unisex');
-    }
-  });
+  const filters = {
+    '#ada_filter': 'accessible',
+    '#unisex_filter': 'unisex',
+    '#changing_table_filter': 'changing_table'
+  }
 
-  $('#changing_table_filter').click(function() {
-    if ($(this).hasClass("active")) {
-      removeFilter('changing_table');
-    } else {
-      addFilter('changing_table');
-    }
-  });
+  Object.entries(filters).forEach(addOnClickEvent);
 });

--- a/app/javascript/packs/views/restrooms/restrooms.js
+++ b/app/javascript/packs/views/restrooms/restrooms.js
@@ -3,6 +3,12 @@
 // You can use CoffeeScript in this file: http://coffeescript.org/
 
 $(() => {
+  const filters = {
+    '#ada_filter': 'accessible',
+    '#unisex_filter': 'unisex',
+    '#changing_table_filter': 'changing_table'
+  };
+
   function getSearchParams() {
     const { search: search } = location;
     return new URLSearchParams(search);
@@ -38,7 +44,8 @@ $(() => {
     applyFilters(filters);
   }
 
-  function addOnClickEvent([filterElementId, filter]) {
+  function addOnClickEvent(filterElementId) {
+    const filter = filters[filterElementId];
     $(filterElementId).click(function() {
       if ($(this).hasClass("active")) {
         removeFilter(filter);
@@ -48,11 +55,5 @@ $(() => {
     });
   }
 
-  const filters = {
-    '#ada_filter': 'accessible',
-    '#unisex_filter': 'unisex',
-    '#changing_table_filter': 'changing_table'
-  }
-
-  Object.entries(filters).forEach(addOnClickEvent);
+  Object.keys(filters).forEach(addOnClickEvent);
 });

--- a/app/views/restrooms/index.html.haml
+++ b/app/views/restrooms/index.html.haml
@@ -2,14 +2,14 @@
   .col-xs-12.headroom
     #filters.clearfix
       .btn-group{:data => {:toggle => "buttons"}}
-        %label#ada_filter.filter.btn.btn-light-purple.linkbutton{:title => t("restroom.accessible")}
-          %input{:type => "checkbox"}
+        %label#ada_filter.filter.btn.btn-light-purple.linkbutton{:title => t("restroom.accessible"), :class => ("active" if @filters.keys.include?('accessible'))}
+          %input{:type => "checkbox", :checked => @filters.keys.include?('accessible')}
           %i.fa.fa-wheelchair
-        %label#unisex_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.type.unisex")}
-          %input{:type => "checkbox"}
+        %label#unisex_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.type.unisex"), :class => ("active" if @filters.keys.include?('unisex'))}
+          %input{:type => "checkbox", :checked => @filters.keys.include?('unisex')}
           %i.fa.fa-transgender-alt
-        %label#changing_table_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.changing_table")}
-          %input{:type => "checkbox"}
+        %label#changing_table_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.changing_table"), :class => ("active" if @filters.keys.include?('changing_table'))}
+          %input{:type => "checkbox", :checked => @filters.keys.include?('changing_table')}
           %i.fa.fa-child
 
       .map-toggle-btn.mapToggle.linkbutton.btn-lg.btn-light-purple

--- a/app/views/restrooms/index.html.haml
+++ b/app/views/restrooms/index.html.haml
@@ -2,13 +2,13 @@
   .col-xs-12.headroom
     #filters.clearfix
       .btn-group{:data => {:toggle => "buttons"}}
-        %label#ada_filter.filter.btn.btn-light-purple.linkbutton{:title => t("restroom.accessible"), :class => ("active" if @filters.keys.include?('accessible'))}
+        %button#ada_filter.filter.btn.btn-light-purple.linkbutton{:title => t("restroom.accessible"), :class => ("active" if @filters.keys.include?('accessible'))}
           %input{:type => "checkbox", :checked => @filters.keys.include?('accessible')}
           %i.fa.fa-wheelchair
-        %label#unisex_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.type.unisex"), :class => ("active" if @filters.keys.include?('unisex'))}
+        %button#unisex_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.type.unisex"), :class => ("active" if @filters.keys.include?('unisex'))}
           %input{:type => "checkbox", :checked => @filters.keys.include?('unisex')}
           %i.fa.fa-transgender-alt
-        %label#changing_table_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.changing_table"), :class => ("active" if @filters.keys.include?('changing_table'))}
+        %button#changing_table_filter.filter.btn-light-purple.btn.linkbutton{:title => t("restroom.changing_table"), :class => ("active" if @filters.keys.include?('changing_table'))}
           %input{:type => "checkbox", :checked => @filters.keys.include?('changing_table')}
           %i.fa.fa-child
 


### PR DESCRIPTION
# Context
- Fixes #226 
- When the user selects a filter on the search page, the filter wasn't being kept by the pagination.

# Summary of Changes

- Frontend:
  - Added functions to manipulate the URL on `apps/javascript/packs/views/restrooms/restrooms.js`
  - The URL is built with `filters` query parameter and sent to the backend.
- Backend:
  - Added a before action `restrooms_filters` to whitelist the given filters;
  - Apply the whitelisted filters to query the database
  - Builds the restroom index view reflecting the filters on the state of the buttons.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
### Page 1
![Screen Shot 2020-10-03 at 22 26 41](https://user-images.githubusercontent.com/4721118/95004931-3f634300-05c8-11eb-9cc5-e7376737dbd6.png)

### Page 2
![Screen Shot 2020-10-03 at 22 26 52](https://user-images.githubusercontent.com/4721118/95004937-586bf400-05c8-11eb-9c39-8d68e4f7f32c.png)

## After

### Page 1
![Screen Shot 2020-10-03 at 22 25 59](https://user-images.githubusercontent.com/4721118/95005016-45a5ef00-05c9-11eb-86f8-ddf114259694.png)

### Page 2
![Screen Shot 2020-10-03 at 22 26 16](https://user-images.githubusercontent.com/4721118/95005009-33c44c00-05c9-11eb-8763-718b35b1d469.png)

