### PR TITLE
Use a volume to deal with bundled gems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,15 @@
 version: '3'
+
+volumes:
+  bundle: 
+    driver: local
+
 services:
   db:
     image: postgres:alpine
     environment:
       POSTGRES_PASSWORD: uaI7m2kmWd949DMv4dCh
+
   web:
     environment:
       PGPASSWORD: uaI7m2kmWd949DMv4dCh
@@ -13,6 +19,7 @@ services:
     volumes:
       - .:/refugerestrooms
       - /refugerestrooms/node_modules
+      - bundle:/usr/local/bundle
     ports:
       - "3000:3000"
     depends_on:

--- a/setup/entry
+++ b/setup/entry
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Check by local gems and if is something is missing, run bundle install
+bundle check || bundle install --jobs 20 --retry 5
+
 # Set up the database for development, and seed with placeholder data from `db/export.csv`
 SEEDING_DONT_GEOCODE="true" rails db:setup
 


### PR DESCRIPTION
# Context
- DX: I want to contribute with this project and I will start sending some PR's upgrading gems, but when I started errors popped out because I need to rebuild the docker image everytime, so with this change my spent time waiting for changes to be downloaded will be much lower.

# Summary of Changes

- Prevent rebuilding docker image everytime a gem changes

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)
