### PR TITLE
Enhancement/i18n thread safe

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,14 +2,18 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  around_action :switch_locale
   before_action :mobile_filter_header
-  before_action :set_locale
 
   def mobile_filter_header
     @mobile = true
   end
 
-  def set_locale
-    I18n.locale = http_accept_language.language_region_compatible_from(I18n.available_locales)
+  def switch_locale(&action)
+    locale = http_accept_language.language_region_compatible_from(I18n.available_locales)
+    locale ||= I18n.default_locale
+
+    I18n.with_locale(locale, &action)
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PagesController, type: :controller  do
+describe PagesController, type: :controller do
   it_behaves_like 'localized request', :index
 
   it "#index" do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-describe PagesController, type: :controller do
+describe PagesController, type: :controller  do
+  it_behaves_like 'localized request', :index
+
   it "#index" do
     get :index
     assert_response :success

--- a/spec/controllers/restrooms_controller_spec.rb
+++ b/spec/controllers/restrooms_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe RestroomsController, type: :controller do
+  it_behaves_like 'localized request', :index
+
   it "#index" do
     get :index
     assert_response :success

--- a/spec/support/shared_examples/localized_request.rb
+++ b/spec/support/shared_examples/localized_request.rb
@@ -1,0 +1,9 @@
+shared_examples_for 'localized request' do |action|
+  it 'calls I18n.with_locale in requests' do
+    allow(I18n).to receive(:with_locale)
+
+    get action
+
+    expect(I18n).to have_received(:with_locale).with(:en)
+  end
+end


### PR DESCRIPTION
# Context
This code makes any request free of locale leaking problems.

According to the rails guides: https://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests
Using `I18n.locale` is not a recommended way to set current locale for a request, using the `with_locale` is the best option!

Btw, searching more about the `http_accept_language` I've found this https://github.com/iain/http_accept_language/issues/68

# Summary of Changes

- Remove `I18n.locale`
- Create shared_examples to test shared behaviour between specs

# Checklist

- [x] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)
