### PR TITLE
Add a standard configuration to every contributor follow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
# Context
When I delivering some pull requests like #648 and #647 I've noticed about my editor not removing trailing spaces to me, then I realized this project have no standard configuration about editor configuration. So, this PR addresses this improvement!

# Summary of Changes

- Added editorconfig
