### PR TITLE
Applying ADA filters for the Map view of search.

### DIFF
--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -8,6 +8,7 @@ class RestroomsController < ApplicationController
   before_action :find_restroom, only: [:show, :update, :edit, :destroy]
 
   def index
+    @view = params[:view] || 'list'
     if params[:nearby]
       render :nearby, layout: false
     else

--- a/app/javascript/packs/views/restrooms/index.js
+++ b/app/javascript/packs/views/restrooms/index.js
@@ -2,7 +2,7 @@ import { Maps } from '../../lib/maps';
 
 let URLParamsParser = window.URLSearchParams;
 
-// Polyfill for Poltergeist.
+// Polyfill for old browsers.
 if (!URLParamsParser) {
   URLParamsParser = function (locationSearch) {
     this.get = (key) => this.queryParams[key];

--- a/app/javascript/packs/views/restrooms/index.js
+++ b/app/javascript/packs/views/restrooms/index.js
@@ -29,6 +29,7 @@ $(function(){
   }
 
   if (getSearchParams().get('view') == 'map') {
+    $("#list").hide();
     $.get('/restrooms' + window.location.search , {}, (points) => {
       const lat = getSearchParams().get('lat');
       const long = getSearchParams().get('long');
@@ -36,5 +37,7 @@ $(function(){
       Maps.loadMapWithPoints(lat, long, points);
       $("#mapContainer").fadeIn(500);
     }, 'json');
+  } else {
+    $("#mapContainer").hide();
   }
 });

--- a/app/views/restrooms/index.html.haml
+++ b/app/views/restrooms/index.html.haml
@@ -12,15 +12,18 @@
           %input{:type => "checkbox", :checked => @filters.keys.include?('changing_table')}
           %i.fa.fa-child
 
-      .map-toggle-btn.mapToggle.linkbutton.btn-lg.btn-light-purple
-        = t('.map-view-button-label')
+      - view_label = @view == 'map' ? 'List View' : 'Map View'
+      - view_toggle = @view == 'map' ? {view: 'list'} : {view: 'map'}
+      = link_to view_label, restrooms_path(request.query_parameters.merge(view_toggle)), class: 'map-toggle-btn linkbutton btn pull-right btn-lg btn-light-purple'
 
 .restrooms-index-content
+- if @view == 'map'
   .row
     .col-sm-12.headroom
       #results
         = content_tag 'div', id: 'mapContainer', data: { latitude: params[:lat], longitude: params[:long] } do
           #mapArea
+- else
   .row
     .col-sm-12.headroom
       %ul{:class => "restrooms-list", :id => "list"}

--- a/app/views/restrooms/index.html.haml
+++ b/app/views/restrooms/index.html.haml
@@ -17,13 +17,11 @@
       = link_to view_label, restrooms_path(request.query_parameters.merge(view_toggle)), class: 'map-toggle-btn linkbutton btn pull-right btn-lg btn-light-purple'
 
 .restrooms-index-content
-- if @view == 'map'
   .row
     .col-sm-12.headroom
       #results
         = content_tag 'div', id: 'mapContainer', data: { latitude: params[:lat], longitude: params[:long] } do
           #mapArea
-- else
   .row
     .col-sm-12.headroom
       %ul{:class => "restrooms-list", :id => "list"}


### PR DESCRIPTION
# Context
- Fixes #479 
- With this PR, the filters will persist during the change of the view from list view to map view. This is being done through query parameters to the controller.

# Summary of Changes

- There's a new instance attribute called `@view` holding one of `list` or `map` values.
- The `index.html.haml` had to be changed to show the list view or the map view of the search restrooms.
- The `index.js` was changed with a new logic to support the new behavior when loading the map.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before
<img width="1167" alt="Screen Shot 2020-10-18 at 16 41 21" src="https://user-images.githubusercontent.com/4721118/96378252-119e0280-1161-11eb-94dd-72c9222ce9a8.png">

<img width="1179" alt="Screen Shot 2020-10-18 at 16 43 03" src="https://user-images.githubusercontent.com/4721118/96378257-182c7a00-1161-11eb-8343-e50d14cd1cef.png">

<img width="1183" alt="Screen Shot 2020-10-18 at 16 43 12" src="https://user-images.githubusercontent.com/4721118/96378262-1f538800-1161-11eb-98d9-e873868e1043.png">


## After
<img width="1189" alt="Screen Shot 2020-10-18 at 16 28 07" src="https://user-images.githubusercontent.com/4721118/96378036-e7981080-115f-11eb-9211-035f6c743697.png">

<img width="1194" alt="Screen Shot 2020-10-18 at 16 28 28" src="https://user-images.githubusercontent.com/4721118/96378037-eb2b9780-115f-11eb-9f40-7e320c3847ab.png">

<img width="1177" alt="Screen Shot 2020-10-18 at 16 28 46" src="https://user-images.githubusercontent.com/4721118/96378040-ee268800-115f-11eb-9f79-6e877e23beb8.png">

<img width="1185" alt="Screen Shot 2020-10-18 at 16 28 59" src="https://user-images.githubusercontent.com/4721118/96378050-f41c6900-115f-11eb-9116-1f43ca1f7150.png">
