### PR TITLE
Revert "Enable puma clustered (#654)"

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,14 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 3 }
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
# Context
- Revert https://github.com/RefugeRestrooms/refugerestrooms/pull/654 / https://github.com/RefugeRestrooms/refugerestrooms/commit/6c63546e3047bfddcf6d51f06ef51921ba4f15be
- Go back to using a single process of Puma.
- Documentation at Heroku for this config option, in case anyone is curious: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#workers

# Summary of Changes

- Go back to using a single process of Puma.
  - We don't have metrics/traffic numbers to motivate the switch to multiple workers on a speed/latency basis. And the app hasn't been thoroughly tested with the multiple workers.
  - We honestly don't understand the potential implications of multiple workers.
  - Revert out of an abundance of caution, as we're making a new release to production soon.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)