### PR TITLE
Fixes Apple M1 Issue w/ Docker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,5 +57,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 volumes:
-  bundle: 
+  bundle:
     driver: local
 
 services:
@@ -11,6 +11,7 @@ services:
       POSTGRES_PASSWORD: uaI7m2kmWd949DMv4dCh
 
   web:
+    platform: linux/amd64
     environment:
       PGPASSWORD: uaI7m2kmWd949DMv4dCh
     build: .


### PR DESCRIPTION
# Context

- Fixes #671 
- `docker-compose up` is not working on Apple M1 environments

# Summary of Changes

- Set platform arm64 for web container
- Stop using `ActiveSupport::EventedFileUpdateChecker`

# Checklist

- [x] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# TODO

- [ ] I don't have an Apple Intel MacBook at the moment. It would be great if someone could test my changes with an Apple Intel environment. 

Thank you! 