### PR TITLE
Update base image to Ubuntu 22.04 "Jammy" in Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=c18df080592f9c99ca8080a6d5e052aa5fd3964044a0fe0b71e48f8e18998dc2
 language: minimal
+dist: jammy
 services: docker
 install:
   - docker-compose build


### PR DESCRIPTION
# Context
- Fixes a strange error in CI (can't reproduce locally) where `apt-get update && apt-get install` errors out before any tests can actually run
- Update the base image for Travis CI from (implicitly/by default) Ubuntu 16.04 "Xenial" to Ubuntu 22.04 "Jammy"

Note that there is one test failing, possibly due to our Google Maps API quota limit being hit, or perhaps it's a billing issue for Google Maps. That said, **this PR is still an improvement**, since CI is getting to the point it can actually run the tests, whereas without this it is erroring out before even getting to the part where the tests run.

# Summary of Changes

- Update Ubuntu base image from (implicitly/by default) Ubuntu 16.04 "Xenial" to Ubuntu 22.04 "Jammy" in `.travis.yml`

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes (CI is still NOT passing with this at the moment I'm making this PR. Possibly due to maps API usage quota being over the limit and this spec scenario requiring search to be actually working, rather than being properly mocked to not require network?? It's only the one test failing)
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle) (N/A. This is a CI-only change, not relevant or applicable to deployment concerns.)
- [ ] Added Documentation (Service and Code when required)
