### PR TITLE
Replace PhantomJS with Chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ RUN apt-get update \
   # Clean up the apt cache
   && rm -rf /var/lib/apt/lists/*
 
-# Work around an issue with running "phantomjs --version"
-ENV OPENSSL_CONF=/etc/ssl/
-
 # Specify a major version of Node.js to download and install
 ENV NODEJS_MAJOR_VERSION=16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,9 @@ FROM ruby:3.2.2-slim
 
 # Add basic binaries
 RUN apt-get update \
-  && apt-get install -y curl g++ gcc libfontconfig libpq-dev make patch xz-utils \
+  && apt-get install -y curl g++ gcc libfontconfig libpq-dev make patch xz-utils chromium \
   # Clean up the apt cache
   && rm -rf /var/lib/apt/lists/*
-
-# Download, extract and install PhantomJS from archive hosted at bitbucket
-RUN curl -L https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O \
-  # Check the file's integrity against its known sha1sum
-  && test "`sha1sum phantomjs-2.1.1-linux-x86_64.tar.bz2`" = "f8afc8a24eec34c2badccc93812879a3d6f2caf3  phantomjs-2.1.1-linux-x86_64.tar.bz2" || (echo "PhantomJS tarball SHA1sum did not match!" && exit 1) \
-  # Extract and clean up the PhantomJS archive
-  && tar xf phantomjs-2.1.1-linux-x86_64.tar.bz2 && rm phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-  # Install PhantomJS binary to /usr/local/bin
-  && mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin \
-  # Clean up extra (un-needed) PhantomJS files
-  && rm -rf phantomjs-2.1.1-linux-x86_64/
 
 # Work around an issue with running "phantomjs --version"
 ENV OPENSSL_CONF=/etc/ssl/

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 group :test do
   gem 'capybara'
   gem 'database_cleaner'
-  gem 'poltergeist'
+  gem 'cuprite'
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'webmock', '~> 3.12.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cliver (0.3.2)
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -136,6 +135,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cuprite (0.15)
+      capybara (~> 3.0)
+      ferrum (~> 0.14.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -175,6 +177,11 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
+    ferrum (0.14)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.16.3)
     formtastic (5.0.0)
       actionpack (>= 6.0.0)
@@ -270,6 +277,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.15.5-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
@@ -284,10 +293,6 @@ GEM
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -464,6 +469,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-19
   x86_64-darwin-21
   x86_64-linux
@@ -478,6 +484,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   country_select
+  cuprite
   database_cleaner
   devise (~> 4.8.1)
   factory_bot_rails (~> 4.8.2)
@@ -497,7 +504,6 @@ DEPENDENCIES
   pagy
   pg
   pg_search
-  poltergeist
   pry
   puma
   rack-cors

--- a/spec/support/locations.rb
+++ b/spec/support/locations.rb
@@ -11,25 +11,12 @@ module Locations
   def mock_location(location_name)
     location = locations[location_name.to_sym]
     page.execute_script "
-      var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
-
-      Refuge.Library.Geocoder = (function() {
-        function Geocoder() {
-          this.getAddress = __bind(this.getAddress, this);
-          this.geocodeSearchString = __bind(this.geocodeSearchString, this);
-        }
-
-        Geocoder.prototype.getCurrentLocation = function() {
-          return jQuery.when(
-            {
-              latitude: #{location[:latitude]},
-              longitude: #{location[:longitude]}
-              });
-        };
-
-        return Geocoder;
-
-      })();
+      navigator.geolocation.getCurrentPosition = function(success, failure) {
+        success({ coords: {
+          latitude: #{location[:latitude]},
+          longitude: #{location[:longitude]}
+        }, timestamp: Date.now() });
+      }
     "
   end
   # rubocop:enable Metrics/MethodLength

--- a/spec/support/locations.rb
+++ b/spec/support/locations.rb
@@ -7,7 +7,6 @@ module Locations
     }
   end
 
-  # rubocop:disable Metrics/MethodLength
   def mock_location(location_name)
     location = locations[location_name.to_sym]
     page.execute_script "
@@ -19,5 +18,4 @@ module Locations
       }
     "
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,4 +1,4 @@
-require 'capybara/poltergeist'
+require 'capybara/cuprite'
 require 'capybara/rspec'
 require 'rspec/rails'
 require 'json'
@@ -7,14 +7,10 @@ require 'json'
 
 require_relative './locations'
 
-Capybara.register_driver :poltergeist_debug do |app|
-  Capybara::Poltergeist::Driver.new(
-    app,
-    js_errors: false
-  )
+Capybara.javascript_driver = :cuprite
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800], browser_options: { 'no-sandbox': nil })
 end
-
-Capybara.javascript_driver = :poltergeist_debug
 
 WebMock.disable_net_connect!(allow_localhost: true)
 

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -9,7 +9,7 @@ require_relative './locations'
 
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800], browser_options: { 'no-sandbox': nil })
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800], browser_options: { 'no-sandbox': nil }, timeout: 30)
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
# Context

Digging the test failure of develop branch, I found that the project is still using old [PhantomJS](https://github.com/ariya/phantomjs)(with [Poltergeist](https://github.com/teampoltergeist/poltergeist)) which is outedated and doesn't support ES6 features. When I try to debug using `page.driver.debug`, I can see console errors including `Unexpected token 'const'`. As I remember there are many weird bugs in PhantomJS. So I just replaced that with Chromium/[Cuprite](https://github.com/rubycdp/cuprite)/[Ferrum](https://github.com/rubycdp/ferrum). Now all tests are passed in my local environment with `docker compose run -e "RAILS_ENV=test" web rake db:test:prepare spec`. But I'm not sure why it was OK before https://github.com/RefugeRestrooms/refugerestrooms/commit/2c70ab90249274eab8ee80366b3deb693eeb8907.

# Summary of Changes

- Remove outdated PhantomJS/Poltergeist dependency.
- Add Chromium to Dockerfile. (I considered Chrome, but the package was not available on Arm environment like linux in docker on apple silicon)
- Add Cuprite dependency with [no-sandbox option for docker.](https://github.com/rubycdp/cuprite?tab=readme-ov-file#install)
- Rewrite functions mocking location to resolve `Refuge is not defined` error.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)
