### PR TITLE
Fix RuboCop errors

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -1,4 +1,4 @@
-# TODO autoloading order changed. This should be managed by configs instead:
+# TODO: autoloading order changed. This should be managed by configs instead:
 # https://guides.rubyonrails.org/v7.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots
 require_relative 'restrooms'
 

--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -17,6 +17,8 @@ class RestroomsController < ApplicationController
     end
   end
 
+  def show; end
+
   # rubocop:disable Metrics/MethodLength
   def new
     if params[:edit_id]
@@ -33,7 +35,7 @@ class RestroomsController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
-  def show; end
+  def edit; end
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
@@ -68,8 +70,6 @@ class RestroomsController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
-
-  def edit; end
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength

--- a/spec/api/v1/restrooms_spec.rb
+++ b/spec/api/v1/restrooms_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Restrooms API", type: :request do
+describe API::V1::Restrooms do
   it 'sends a list of restrooms order by date descending' do
     create_list(:restroom, 15)
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PagesController, type: :controller do
+describe PagesController do
   it_behaves_like 'localized request', :index
 
   it "#index" do

--- a/spec/controllers/restrooms_controller_spec.rb
+++ b/spec/controllers/restrooms_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RestroomsController, type: :controller do
+describe RestroomsController do
   it_behaves_like 'localized request', :index
 
   it "#index" do

--- a/spec/features/contacts_spec.rb
+++ b/spec/features/contacts_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'the contact process', type: :feature do
+describe 'the contact process' do
   it 'shows a generic contact when contact is not from restroom form' do
     restroom = create(:restroom, name: "Mission Creek Cafe")
 

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'restrooms', type: :feature, js: true do
+describe 'restrooms', :js do
   describe 'submission' do
     it 'adds a restroom when submitted' do
       visit root_path

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -47,7 +47,7 @@ describe 'restrooms', type: :feature, js: true do
 
       visit root_path
       fill_in 'search', with: 'San Francisco'
-      click_on 'Search'
+      click_button 'Search'
 
       expect(page).to have_content 'Mission Creek Cafe'
     end
@@ -57,7 +57,7 @@ describe 'restrooms', type: :feature, js: true do
 
       visit root_path
       mock_location "Oakland"
-      click_on 'Search by Current Location'
+      click_button 'Search by Current Location'
 
       expect(page).not_to have_content 'Some Cafe'
     end
@@ -99,7 +99,7 @@ describe 'restrooms', type: :feature, js: true do
       fill_in "restroom[state]", with: "British Columbia"
       find(:select, "Country").first(:option, "Canada").select_option
 
-      click_on "Preview"
+      click_button "Preview"
 
       page.has_css?(".nearby-container .listItem", visible: :visible)
     end
@@ -136,7 +136,7 @@ describe 'restrooms', type: :feature, js: true do
       click_link "Propose an edit to this listing."
 
       fill_in "restroom[directions]", with: "This is an edit"
-      click_on "Save Restroom"
+      click_button "Save Restroom"
 
       expect(page).to have_content("Your edit has been submitted.")
       expect(Restroom.where(edit_id: restroom.id).size).to eq(2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,8 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.infer_spec_type_from_file_location!
+
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join("/spec/fixtures")
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -5,7 +5,7 @@ require 'json'
 # spec/spec_helper.rb
 #
 
-require_relative './locations'
+require_relative 'locations'
 
 Capybara.register_driver :poltergeist_debug do |app|
   Capybara::Poltergeist::Driver.new(


### PR DESCRIPTION
# Context
Fixed RuboCop errors that occurred after #689. These errors seem to be caused by upgrading rubocop-* gems. For example, rubocop-rspec, which was 2.13.2, [added RSpec/Rails/InferredSpecType since 2.14](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.14.0).

# Summary of Changes

- Fixed RuboCop errors
- [Added `config.infer_spec_type_from_file_location!`](https://makandracards.com/makandra/508369-rspec-inferring-spec-type-from-file-location) to satisfy [RSpec/Rails/InferredSpecType](https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsinferredspectype).

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
