### PR TITLE
Add missing expectations to restrooms_spec

### DIFF
--- a/app/javascript/packs/lib/maps.js.erb
+++ b/app/javascript/packs/lib/maps.js.erb
@@ -33,6 +33,7 @@ function initMap(x, y, image, draggable, callback){
   var myLatLng = new google.maps.LatLng(x, y);
 
   var currentLocation = new google.maps.Marker({
+    title: "Current Location",
     position: myLatLng,
     draggable: draggable,
     map: map,

--- a/spec/factories/restrooms.rb
+++ b/spec/factories/restrooms.rb
@@ -46,6 +46,8 @@ FactoryBot.define do
       city { 'Oakland' }
       state { 'CA' }
       country { 'US' }
+      latitude { 37.8044 }
+      longitude { -122.27081 }
     end
 
     factory :spam_restroom do

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -70,26 +70,22 @@ describe 'restrooms', :js do
       expect(find('button.current-location-button')['aria-label']).to be_truthy
     end
 
-    # rubocop:disable RSpec/NoExpectationExample
     it 'displays a map' do
       create(:oakland_restroom)
 
       visit root_path
       mock_location "Oakland"
       find('.current-location-button').click
-      # TODO: Figure out why this isn't working.
-      # print page.html
-      page.has_css?(".mapToggle", visible: true)
-      # find('.mapToggle').click
-      # print page.html
+      expect(page).to have_css(".map-toggle-btn", visible: :visible)
 
-      # TODO: Figure Out why This isn't working either
-      # page.has_css?(#)
-      # expect(page).to have_css('#mapArea.loaded')
-      # expect(page).to have_css('#mapArea .numberCircleText')
+      find('.map-toggle-btn').click
+
+      expect(page).to have_css('#mapArea.loaded')
+      expect(page).to have_css("#mapArea [role=button][aria-label='1']")
     end
   end
 
+  # rubocop:disable RSpec/NoExpectationExample
   describe 'preview' do
     it 'can preview a restroom before submitting' do
       visit "/"

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -85,7 +85,6 @@ describe 'restrooms', :js do
     end
   end
 
-  # rubocop:disable RSpec/NoExpectationExample
   describe 'preview' do
     it 'can preview a restroom before submitting' do
       visit "/"
@@ -98,10 +97,12 @@ describe 'restrooms', :js do
 
       click_button "Preview"
 
-      page.has_css?(".nearby-container .listItem", visible: :visible)
+      expect(page).to have_css("div#mapArea", visible: :visible)
+      expect(page).to have_css("div#mapArea [title='Current Location']", visible: :visible)
     end
   end
 
+  # rubocop:disable RSpec/NoExpectationExample
   describe 'nearby restroom' do
     it 'shows nearby restrooms when they exist' do
       create(:oakland_restroom)

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -102,7 +102,6 @@ describe 'restrooms', :js do
     end
   end
 
-  # rubocop:disable RSpec/NoExpectationExample
   describe 'nearby restroom' do
     it 'shows nearby restrooms when they exist' do
       create(:oakland_restroom)
@@ -112,7 +111,7 @@ describe 'restrooms', :js do
 
       find(".guess-btn").click
 
-      page.has_css?(".nearby-container .listItem", visible: :visible)
+      expect(page).to have_css(".nearby-container .listItem", visible: :visible)
     end
 
     it "does not show nearby restrooms when they don't exist" do
@@ -122,10 +121,9 @@ describe 'restrooms', :js do
 
       find(".guess-btn").click
 
-      page.has_css?(".nearby-container .none", visible: :visible)
+      expect(page).to have_css(".nearby-container .none", visible: :visible)
     end
   end
-  # rubocop:enable RSpec/NoExpectationExample
 
   describe "edit" do
     it "creates an edit listing" do

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -28,17 +28,18 @@ describe 'restrooms', :js do
       expect(page).to have_content("Your submission was rejected as spam.")
     end
 
-    # it "should guess my location" do
-    #   visit "/"
-    #   click_link "Submit a New Restroom"
-    #   mock_location("Oakland")
+    it 'guesses my location' do
+      visit "/"
+      click_link "Submit a New Restroom"
+      mock_location("Oakland")
 
-    #   find(".guess-btn").click
+      click_button 'Guess current location'
+      page.driver.wait_for_network_idle
 
-    #   expect(page).to have_field('restroom[street]', with: "1400 Broadway")
-    #   expect(page).to have_field('restroom[city]', with: "Oakland")
-    #   expect(page).to have_field('restroom[state]', with: "CA")
-    # end
+      expect(page).to have_field('restroom[street]', with: "1400 Broadway")
+      expect(page).to have_field('restroom[city]', with: "Oakland")
+      expect(page).to have_field('restroom[state]', with: "California")
+    end
   end
 
   describe 'search' do
@@ -59,7 +60,7 @@ describe 'restrooms', :js do
       mock_location "Oakland"
       click_button 'Search by Current Location'
 
-      expect(page).not_to have_content 'Some Cafe'
+      expect(page).to have_content 'Some Cafe'
     end
 
     it 'can search from the splash page with a screen reader' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,3 +62,20 @@ Geocoder::Lookup::Test.add_stub(
     }
   ]
 )
+
+Geocoder::Lookup::Test.add_stub(
+  [37.8044, -122.2708],
+  [
+    {
+      "latitude" => 37.8044652,
+      "longitude" => -122.27081,
+      "address" => "1400 Broadway, Oakland, CA 94612, USA",
+      "street" => "1400 Broadway",
+      "city" => "Oakland",
+      "state" => "California",
+      "state_code" => "CA",
+      "country" => "United States",
+      "country_code" => "US"
+    }
+  ]
+)


### PR DESCRIPTION
# Context
- Completed the unfinished tests and removed the comments that disabled RuboCop checks in restroom_spec, as mentioned on https://github.com/RefugeRestrooms/refugerestrooms/pull/691#discussion_r1590504890).

# Summary of Changes

- Added Oakland's information as a stub to Geocoder to resolve `unknown stub request` error in [restrooms_controller L30](https://github.com/RefugeRestrooms/refugerestrooms/blob/994fe4877b186eeecfc26d78001c6bbc1d6fcb09/app/controllers/restrooms_controller.rb#L30), which occured during the "It guesses my location" spec. The information is the same as declared in [guess_in_oakland.json](https://github.com/RefugeRestrooms/refugerestrooms/blob/994fe4877b186eeecfc26d78001c6bbc1d6fcb09/spec/fixtures/guess_in_oakland.json#L46-L51).
- Added a title to the current location marker to enable its selection during tests. But [as google deprecated google.maps.Marker](https://developers.google.com/maps/documentation/javascript/advanced-markers/migration?hl=en), I think that we should migrate it to use advanced marker API soon.
- Added a coordinate to `:oakland_restroom` factory to display the restroom when the map is focused on Oakland. Although there is already `:geocoded` trait, considering the name of fixture, I thought it was reasonable to add the coodinate.

# Checklist

- [ ] Tested Mobile Responsiveness
- [ ] Added Unit Tests
- [ ] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
