### PR TITLE
Fix rails-ujs import syntax causing thumbs up/down buttons to not work

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,5 +1,7 @@
 // Vendor
-require('@rails/ujs').start()
+import Rails from '@rails/ujs'
+Rails.start()
+
 require('jquery')
 import 'bootstrap/dist/js/bootstrap'
 

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -142,4 +142,32 @@ describe 'restrooms', :js do
       expect(Restroom.where(edit_id: restroom.id).size).to eq(2)
     end
   end
+
+  describe "vote" do
+    it "shows 'Not yet rated' message initially" do
+      restroom = create(:restroom, upvote: 0, downvote: 0)
+
+      visit "/restrooms/#{restroom.id}"
+
+      expect(page).to have_content("Not yet rated")
+    end
+
+    it "can downvote" do
+      restroom = create(:restroom, upvote: 0, downvote: 0)
+
+      visit "/restrooms/#{restroom.id}"
+      click_button "Thumbs Down"
+
+      expect(page).to have_content("0% positive")
+    end
+
+    it "can upvote" do
+      restroom = create(:restroom, upvote: 0, downvote: 0)
+
+      visit "/restrooms/#{restroom.id}"
+      click_button "Thumbs Up"
+
+      expect(page).to have_content("100% positive")
+    end
+  end
 end


### PR DESCRIPTION
# Context

- Currently there is `__webpack_require__(...).start is not a function` error in the JavaScript console. This error seems to have appeared after a recent upgrade to Rails 7. If I downgrade rails-ujs to 6.x, the error disappears. Additionally, it seems to break some functionallity that uses rails-ujs. This PR fixes the error and adds tests to prevent regression, as there were no existing tests for this functionality.

# Summary of Changes

- Fix js error by following [current documentation of rails-ujs](https://github.com/rails/rails/tree/7-1-stable/actionview/app/javascript#es2015).
- Add missing specs to prevent regression and ensure the voting functionality works as expected.

# Checklist

- [ ] Tested Mobile Responsiveness
- [x] Added Unit Tests
- [x] CI Passes
- [ ] Deploys to Heroku on test Correctly (Maintainers will handle)
- [ ] Added Documentation (Service and Code when required)

# Screenshots

## Before

## After
