### PR TITLE
Fix DoubleRenderError in update action and simplify display_errors

### DIFF
--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -83,6 +83,7 @@ class RestroomsController < ApplicationController
     else
       display_errors
       render 'edit'
+      return
     end
 
     redirect_to @restroom
@@ -117,9 +118,7 @@ class RestroomsController < ApplicationController
 
   def display_errors
     if @restroom.errors.any?
-      @restroom.errors.each do
-        flash[:alert] = I18n.t('restroom.flash.field')
-      end
+      flash[:alert] = I18n.t('restroom.flash.field')
     else
       flash[:alert] = I18n.t('restroom.flash.unexpected')
     end


### PR DESCRIPTION
## What

This PR fixes two bugs in `RestroomsController`:

### Bug 1: `AbstractController::DoubleRenderError` in `update`

In the `update` action, when a restroom fails validation during an edit, the code called both `render 'edit'` **and** then fell through to the unconditional `redirect_to @restroom` below it. This raises an `AbstractController::DoubleRenderError` at runtime.

**Before:**
```ruby
else
  display_errors
  render 'edit'
end

redirect_to @restroom  # always executes — crashes when render already called
```

**After:**
```ruby
else
  display_errors
  render 'edit'
  return  # prevents fall-through to redirect_to
end

redirect_to @restroom
```

### Bug 2: Redundant iteration in `display_errors`

The `display_errors` helper iterated over `@restroom.errors.each do` but had **no block parameter**. On every iteration it simply overwrote the same `flash[:alert]` key with the same value — a no-op loop that just sets the same string repeatedly and then discards it.

**Before:**
```ruby
@restroom.errors.each do
  flash[:alert] = I18n.t('restroom.flash.field')
end
```

**After:**
```ruby
flash[:alert] = I18n.t('restroom.flash.field')
```

## Impact

- Editing an existing restroom and submitting invalid data would previously crash with a `DoubleRenderError` instead of showing the edit form with an error message.
- No behaviour change for valid submissions or voting actions.
