### PR TITLE
Allow /restrooms/new to prefill the submission form from URL params

### DIFF
--- a/app/controllers/restrooms_controller.rb
+++ b/app/controllers/restrooms_controller.rb
@@ -19,6 +19,7 @@ class RestroomsController < ApplicationController
 
   def show; end
 
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
   def new
     if params[:edit_id]
@@ -29,10 +30,20 @@ class RestroomsController < ApplicationController
       @restroom = Restroom.new(permitted_params)
       @restroom.reverse_geocode
       render 'new', layout: false
+    elsif params[:restroom].is_a?(ActionController::Parameters)
+      # Prefill the normal styled form from URL params (e.g. a third-party
+      # app deep-linking known details into a new submission). Unlike :guess,
+      # we keep the full layout and skip reverse-geocoding so the supplied
+      # name/address are preserved rather than overwritten. Values are escaped
+      # by the form helpers; nothing is persisted (create still enforces
+      # reCAPTCHA + moderation). The is_a? guard keeps a malformed non-hash
+      # `restroom` param (e.g. ?restroom=foo) on the blank-form path.
+      @restroom = Restroom.new(permitted_params)
     else
       @restroom = Restroom.new
     end
   end
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 
   def edit; end

--- a/spec/features/restrooms_spec.rb
+++ b/spec/features/restrooms_spec.rb
@@ -139,6 +139,31 @@ describe 'restrooms', :js do
     end
   end
 
+  describe "prefill" do
+    it "prefills the new-restroom form from URL params" do
+      visit "/restrooms/new?restroom[name]=Powell's Books" \
+            "&restroom[street]=1005 W Burnside St" \
+            "&restroom[city]=Portland&restroom[state]=OR"
+
+      expect(page).to have_field('restroom[name]', with: "Powell's Books")
+      expect(page).to have_field('restroom[street]', with: "1005 W Burnside St")
+      expect(page).to have_field('restroom[city]', with: "Portland")
+      expect(page).to have_field('restroom[state]', with: "OR")
+    end
+
+    it "renders a blank form when no params are given" do
+      visit "/restrooms/new"
+
+      expect(page).to have_field('restroom[name]', with: "")
+    end
+
+    it "safely ignores a malformed (non-hash) restroom param" do
+      visit "/restrooms/new?restroom=foo"
+
+      expect(page).to have_field('restroom[name]', with: "")
+    end
+  end
+
   describe "vote" do
     it "shows 'Not yet rated' message initially" do
       restroom = create(:restroom, upvote: 0, downvote: 0)


### PR DESCRIPTION
# Context

- Fixes #701
- Allow `/restrooms/new` to prefill the styled submission form from URL params, so third-party apps/links can deep-link a partially-filled **new** submission. Not a write API — still goes through the form + reCAPTCHA + moderation.

# Summary of Changes

- `RestroomsController#new`: new `elsif params[:restroom].is_a?(ActionController::Parameters)` branch builds `Restroom.new(permitted_params)` with the normal layout and **no `reverse_geocode`**, so a supplied name/address is preserved rather than overwritten. The `edit_id`, `guess`, and blank-form paths are unchanged. The `is_a?` guard keeps a malformed non-hash `restroom` param (e.g. `?restroom=foo`) on the safe blank-form path.
- Reuses the existing `permitted_params` strong-params whitelist; values are escaped by the form helpers (no new injection surface), and **nothing is persisted** — creating a listing still goes through `create` → reCAPTCHA → moderation.
- Adds feature specs: prefill populates the fields, blank form by default, and a malformed param renders the blank form rather than erroring.

# Checklist

- [x] Tested Mobile Responsiveness *(no UI change — form markup untouched)*
- [x] Added Unit Tests *(feature specs)*
- [x] CI Passes *(repo's Travis appears inactive; verified locally via docker-compose — full RSpec suite 71 examples / 0 failures, RuboCop clean)*
- [ ] Deploys to Heroku on test Correctly *(Maintainers will handle)*
- [x] Added Documentation *(inline comment on the new branch)*

# Screenshots

## Before

`/restrooms/new` — blank form (unchanged default):

![Before: blank new-restroom form](https://raw.githubusercontent.com/tonyfonseca/refugerestrooms/pr-702-screenshots/screenshots/before-blank.png)

## After

`/restrooms/new?restroom[name]=Powell's Books&restroom[street]=1005 W Burnside St&restroom[city]=Portland&restroom[state]=OR` — Name / Street / City / State pre-filled, everything else (styling, reCAPTCHA, submit) unchanged:

![After: new-restroom form prefilled from URL params](https://raw.githubusercontent.com/tonyfonseca/refugerestrooms/pr-702-screenshots/screenshots/after-prefilled.png)

---

_Note for maintainers: building the Docker image on Apple Silicon currently fails because the Dockerfile pins the `linux-x64` Node binary (`rosetta error … ld-linux-x86-64.so.2`); building with `DOCKER_DEFAULT_PLATFORM=linux/amd64` works around it. Unrelated to this change — happy to file separately if useful._
